### PR TITLE
Add doc_md_validation rule

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -84,6 +84,16 @@ Config is loaded from `.daglint.yaml` in the working directory, or falls back to
    issues = rule.check(tree, "test.py", code)
    ```
 
+## Git Workflow
+
+- All work must be done on a branch named after the GitHub issue (e.g., `issue-42`).
+- Always start from a fresh pull of the `develop` branch:
+  ```bash
+  git checkout develop && git pull origin develop
+  git checkout -b issue-<number>
+  ```
+- Pull requests must target the `develop` branch (not `main`).
+
 ## Key Conventions
 
 - Rules are detected as abstract if `inspect.isabstract()` returns `True` — `BaseRule` is skipped automatically.

--- a/src/daglint/config.py
+++ b/src/daglint/config.py
@@ -72,6 +72,10 @@ class Config:
                     "default_catchup": False,
                     "severity": "warning",
                 },
+                "doc_md_validation": {
+                    "enabled": True,
+                    "severity": "warning",
+                },
             }
         }
 

--- a/src/daglint/rules/__init__.py
+++ b/src/daglint/rules/__init__.py
@@ -9,6 +9,7 @@ from daglint.rules.configuration import (
     ScheduleValidationRule,
 )
 from daglint.rules.metadata import (
+    DocMdValidationRule,
     MaxActiveRunsValidationRule,
     OwnerValidationRule,
     RequiredDAGParamsRule,
@@ -20,6 +21,7 @@ from daglint.rules.validation import NoDuplicateTaskIDsRule
 # Registry of all available rules
 AVAILABLE_RULES: Dict[str, Type[BaseRule]] = {
     "dag_id_convention": DAGIDConventionRule,
+    "doc_md_validation": DocMdValidationRule,
     "owner_validation": OwnerValidationRule,
     "task_id_convention": TaskIDConventionRule,
     "retry_configuration": RetryConfigurationRule,
@@ -33,6 +35,7 @@ AVAILABLE_RULES: Dict[str, Type[BaseRule]] = {
 
 __all__ = [
     "DAGIDConventionRule",
+    "DocMdValidationRule",
     "OwnerValidationRule",
     "TaskIDConventionRule",
     "RetryConfigurationRule",

--- a/src/daglint/rules/metadata/__init__.py
+++ b/src/daglint/rules/metadata/__init__.py
@@ -5,14 +5,17 @@ This package contains rules for validating DAG metadata such as:
 - Tag requirements
 - Required DAG parameters
 - max_active_runs defaults
+- doc_md documentation
 """
 
+from daglint.rules.metadata.doc_md_validation import DocMdValidationRule
 from daglint.rules.metadata.max_active_runs_validation import MaxActiveRunsValidationRule
 from daglint.rules.metadata.owner_validation import OwnerValidationRule
 from daglint.rules.metadata.required_dag_params import RequiredDAGParamsRule
 from daglint.rules.metadata.tag_requirements import TagRequirementsRule
 
 __all__ = [
+    "DocMdValidationRule",
     "MaxActiveRunsValidationRule",
     "OwnerValidationRule",
     "TagRequirementsRule",

--- a/src/daglint/rules/metadata/doc_md_validation.py
+++ b/src/daglint/rules/metadata/doc_md_validation.py
@@ -1,0 +1,61 @@
+"""Rule for validating DAG doc_md documentation."""
+
+import ast
+from typing import List, Optional
+
+from daglint.models import LintIssue
+from daglint.rules.base import BaseRule
+
+
+class DocMdValidationRule(BaseRule):
+    """Validates that DAGs have doc_md set."""
+
+    @property
+    def rule_id(self) -> str:
+        return "doc_md_validation"
+
+    @property
+    def description(self) -> str:
+        return "DAGs must have doc_md set to provide documentation"
+
+    def check(self, tree: ast.AST, file_path: str, source_code: str) -> List[LintIssue]:
+        issues = []
+
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call):
+                if isinstance(node.func, ast.Name) and node.func.id == "DAG":
+                    doc_md = self._extract_doc_md(node)
+                    if doc_md is None:
+                        issues.append(
+                            self.create_issue(
+                                "DAG is missing doc_md documentation",
+                                file_path,
+                                node.lineno,
+                                node.col_offset,
+                            )
+                        )
+                    elif doc_md.strip() == "":
+                        issues.append(
+                            self.create_issue(
+                                "DAG doc_md must not be empty",
+                                file_path,
+                                node.lineno,
+                                node.col_offset,
+                            )
+                        )
+
+        return issues
+
+    def _extract_doc_md(self, node: ast.Call) -> Optional[str]:
+        """Extract doc_md value from a DAG() call.
+
+        Returns None if doc_md is absent, the string value if it's a string literal,
+        or a non-empty sentinel if it's any other expression (variable, call, etc.).
+        """
+        for keyword in node.keywords:
+            if keyword.arg == "doc_md":
+                if isinstance(keyword.value, ast.Constant) and isinstance(keyword.value.value, str):
+                    return keyword.value.value
+                # Variable or other expression — treat as non-empty
+                return "<expression>"
+        return None

--- a/tests/rules/test_doc_md_validation.py
+++ b/tests/rules/test_doc_md_validation.py
@@ -1,0 +1,116 @@
+"""Tests for doc_md validation rule."""
+
+import ast
+
+from daglint.rules.metadata import DocMdValidationRule
+
+
+class TestDocMdValidationRule:
+    """Tests for doc_md validation rule."""
+
+    def test_dag_with_doc_md_passes(self):
+        """Test that a DAG with doc_md set passes."""
+        code = """
+from airflow import DAG
+
+dag = DAG('my_dag', doc_md=\"\"\"This is my DAG documentation.\"\"\")
+"""
+        tree = ast.parse(code)
+        rule = DocMdValidationRule()
+        issues = rule.check(tree, "test.py", code)
+        assert len(issues) == 0
+
+    def test_dag_without_doc_md_fails(self):
+        """Test that a DAG without doc_md is flagged."""
+        code = """
+from airflow import DAG
+
+dag = DAG('my_dag', schedule_interval='@daily')
+"""
+        tree = ast.parse(code)
+        rule = DocMdValidationRule()
+        issues = rule.check(tree, "test.py", code)
+        assert len(issues) == 1
+        assert "missing doc_md" in issues[0].message
+
+    def test_dag_with_empty_doc_md_fails(self):
+        """Test that a DAG with an empty doc_md string is flagged."""
+        code = """
+from airflow import DAG
+
+dag = DAG('my_dag', doc_md='')
+"""
+        tree = ast.parse(code)
+        rule = DocMdValidationRule()
+        issues = rule.check(tree, "test.py", code)
+        assert len(issues) == 1
+        assert "must not be empty" in issues[0].message
+
+    def test_dag_with_whitespace_doc_md_fails(self):
+        """Test that a DAG with a whitespace-only doc_md is flagged."""
+        code = """
+from airflow import DAG
+
+dag = DAG('my_dag', doc_md='   ')
+"""
+        tree = ast.parse(code)
+        rule = DocMdValidationRule()
+        issues = rule.check(tree, "test.py", code)
+        assert len(issues) == 1
+        assert "must not be empty" in issues[0].message
+
+    def test_dag_with_variable_doc_md_passes(self):
+        """Test that doc_md assigned from a variable is accepted."""
+        code = """
+from airflow import DAG
+
+DOC = "Some documentation"
+dag = DAG('my_dag', doc_md=DOC)
+"""
+        tree = ast.parse(code)
+        rule = DocMdValidationRule()
+        issues = rule.check(tree, "test.py", code)
+        assert len(issues) == 0
+
+    def test_multiple_dags_both_missing(self):
+        """Test that multiple DAGs without doc_md each produce an issue."""
+        code = """
+from airflow import DAG
+
+dag1 = DAG('dag1')
+dag2 = DAG('dag2')
+"""
+        tree = ast.parse(code)
+        rule = DocMdValidationRule()
+        issues = rule.check(tree, "test.py", code)
+        assert len(issues) == 2
+
+    def test_multiple_dags_one_missing(self):
+        """Test that only the DAG without doc_md is flagged."""
+        code = """
+from airflow import DAG
+
+dag1 = DAG('dag1', doc_md='Documented.')
+dag2 = DAG('dag2')
+"""
+        tree = ast.parse(code)
+        rule = DocMdValidationRule()
+        issues = rule.check(tree, "test.py", code)
+        assert len(issues) == 1
+        assert "missing doc_md" in issues[0].message
+
+    def test_non_dag_call_ignored(self):
+        """Test that non-DAG callable with doc_md kwarg is not flagged."""
+        code = """
+some_function(doc_md='irrelevant')
+"""
+        tree = ast.parse(code)
+        rule = DocMdValidationRule()
+        issues = rule.check(tree, "test.py", code)
+        assert len(issues) == 0
+
+    def test_rule_has_metadata(self):
+        """Test that rule has required metadata."""
+        rule = DocMdValidationRule()
+        assert rule.rule_id == "doc_md_validation"
+        assert len(rule.description) > 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -35,6 +35,7 @@ with DAG(
     max_active_runs=1,
     catchup=False,
     tags=['environment', 'team'],
+    doc_md='A valid DAG for testing.',
 ) as dag:
     
     task1 = PythonOperator(


### PR DESCRIPTION
Closes #19

## Summary

Adds a new `doc_md_validation` rule that enforces all DAGs have `doc_md` set.

## Changes

- **New rule**: `DocMdValidationRule` in `src/daglint/rules/metadata/doc_md_validation.py`
  - Flags DAGs missing `doc_md` entirely
  - Flags DAGs with an empty or whitespace-only `doc_md` string
  - Accepts variables/expressions as valid values
- Registered in `AVAILABLE_RULES`, enabled by default with `severity: warning`
- Added default config entry in `Config._default_config()`
- 9 new tests in `tests/rules/test_doc_md_validation.py`
- Updated CLI test fixture to include `doc_md`
- Added Git Workflow guidelines to `.github/copilot-instructions.md`