### PR TITLE
Set up branch protection rules and git workflow

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -84,6 +84,32 @@ Config is loaded from `.daglint.yaml` in the working directory, or falls back to
    issues = rule.check(tree, "test.py", code)
    ```
 
+## Git Workflow
+
+The branching model is: `issue-<number>` → `develop` → `main` (releases only).
+
+### Feature work
+- All work must be done on a branch named after the GitHub issue (e.g., `issue-42`).
+- Always start from a fresh pull of the `develop` branch:
+  ```bash
+  git checkout develop && git pull origin develop
+  git checkout -b issue-<number>
+  ```
+- Pull requests must target `develop` (not `main`).
+- CI must pass and all review comments must be resolved before merge.
+
+### Releasing
+1. On `develop`, run `bumpver` to bump the version (creates a commit + tag locally):
+   ```bash
+   bumpver update --minor --no-fetch   # or --patch / --major
+   ```
+2. Open a PR from `develop` → `main`. This is the release PR — include CHANGELOG updates.
+3. After the PR merges, push the tag and publish manually:
+   ```bash
+   git push origin --tags
+   python -m build && python -m twine upload dist/*
+   ```
+
 ## Key Conventions
 
 - Rules are detected as abstract if `inspect.isabstract()` returns `True` — `BaseRule` is skipped automatically.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,16 +65,40 @@ mypy src/daglint
 pytest
 ```
 
+## Git Workflow
+
+The branching model is: `issue-<number>` → `develop` → `main` (releases only).
+
+### Feature work
+- All work must be done on a branch named after the GitHub issue (e.g., `issue-42`).
+- Always start from a fresh pull of the `develop` branch:
+  ```bash
+  git checkout develop && git pull origin develop
+  git checkout -b issue-<number>
+  ```
+- Pull requests must target `develop` (not `main`).
+- CI must pass and all review comments must be resolved before merge.
+
+### Releasing
+1. On `develop`, run `bumpver` to bump the version (creates a commit + tag):
+   ```bash
+   bumpver update --minor --no-fetch   # or --patch / --major
+   ```
+2. Update `CHANGELOG.md` then open a PR from `develop` → `main`.
+3. After the PR merges, push the tag and publish manually:
+   ```bash
+   git push origin --tags
+   python -m build && python -m twine upload dist/*
+   ```
+
 ## Pull Request Process
 
-1. Fork the repository
-2. Create a feature branch (`git checkout -b feature/amazing-feature`)
-3. Make your changes
-4. Add tests for your changes
-5. Ensure all tests pass
-6. Commit your changes (`git commit -m 'Add amazing feature'`)
-7. Push to the branch (`git push origin feature/amazing-feature`)
-8. Open a Pull Request
+1. Create a branch named `issue-<number>` from `develop`
+2. Make your changes with tests
+3. Ensure all tests and linting pass: `make check`
+4. Commit your changes with a descriptive message
+5. Push and open a PR targeting `develop`
+6. Resolve all review comments before merging
 
 ## Coding Standards
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -148,9 +148,11 @@ repos:
 
 ## Publishing to PyPI
 
-When ready to publish a new version:
+When ready to release, the workflow is: bump the version on `develop`, open a PR to `main`, merge, push the tag, then publish manually.
 
 ### 1. Update Version with Bumpver
+
+Run on the `develop` branch before opening the release PR:
 
 ```bash
 # Preview the version bump
@@ -208,11 +210,13 @@ python -m twine upload dist/*
 
 You'll be prompted for your PyPI credentials or API token.
 
-### 6. Push Changes to GitHub
+### 6. Push Tag and Verify
+
+After the release PR (`develop` → `main`) has been merged:
 
 ```bash
-# Push the commit and tags
-git push origin main --tags
+# Push the version tag created by bumpver
+git push origin --tags
 ```
 
 ### Authentication Options


### PR DESCRIPTION
Closes #21

## Summary

Establishes the full branch protection setup and formalises the git workflow in documentation.

## GitHub settings applied (via API)
- ✅ Branch protection on `main`: PR required, CI status checks required, conversations must be resolved, no force push, strict up-to-date
- ✅ Branch protection on `develop`: same settings
- ✅ Auto-delete head branches enabled on the repo

## Required status checks (both branches)
- Test on Python 3.10 / 3.11 / 3.12
- Build package
- Pull Request Validation

## Documentation changes
- `.github/copilot-instructions.md` — added Git Workflow section (feature → develop → main, bumpver on develop before release PR)
- `CONTRIBUTING.md` — replaced old PR process with full branching model and release workflow
- `DEPLOYMENT.md` — updated Publishing section to reflect develop-based release workflow and correct tag-push step