### PR TITLE
fix: scope owner_validation to default_args dicts only

### DIFF
--- a/src/daglint/rules/base.py
+++ b/src/daglint/rules/base.py
@@ -60,6 +60,21 @@ class BaseRule(ABC):
             return node.func.attr.endswith("Operator")
         return False
 
+    def _is_dag_call(self, node: ast.Call) -> bool:
+        """Check if a call is a DAG instantiation.
+
+        Args:
+            node: AST Call node to check
+
+        Returns:
+            True if the call is a DAG instantiation
+        """
+        if isinstance(node.func, ast.Name):
+            return node.func.id == "DAG"
+        elif isinstance(node.func, ast.Attribute):
+            return node.func.attr == "DAG"
+        return False
+
     def _extract_task_id(self, node: ast.Call) -> Optional[str]:
         """Extract task_id from an operator call.
 
@@ -122,7 +137,7 @@ class BaseRule(ABC):
                     isinstance(target, ast.Name) and target.id == "default_args" for target in node.targets
                 ):
                     dicts.append(node.value)
-            elif isinstance(node, ast.Call):
+            elif isinstance(node, ast.Call) and self._is_dag_call(node):
                 for keyword in node.keywords:
                     if keyword.arg == "default_args" and isinstance(keyword.value, ast.Dict):
                         dicts.append(keyword.value)

--- a/src/daglint/rules/base.py
+++ b/src/daglint/rules/base.py
@@ -102,6 +102,32 @@ class BaseRule(ABC):
 
         return None
 
+    def _find_default_args_dicts(self, tree: ast.AST) -> List[ast.Dict]:
+        """Find dict literals bound to default_args.
+
+        Matches both forms:
+            default_args = {...}
+            DAG(..., default_args={...})
+
+        Args:
+            tree: Abstract syntax tree of the file
+
+        Returns:
+            List of AST Dict nodes bound to default_args
+        """
+        dicts = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Assign):
+                if isinstance(node.value, ast.Dict) and any(
+                    isinstance(target, ast.Name) and target.id == "default_args" for target in node.targets
+                ):
+                    dicts.append(node.value)
+            elif isinstance(node, ast.Call):
+                for keyword in node.keywords:
+                    if keyword.arg == "default_args" and isinstance(keyword.value, ast.Dict):
+                        dicts.append(keyword.value)
+        return dicts
+
     def create_issue(self, message: str, file_path: str, line: int, column: int = 0) -> LintIssue:
         """Create a linting issue.
 

--- a/src/daglint/rules/metadata/max_active_runs_validation.py
+++ b/src/daglint/rules/metadata/max_active_runs_validation.py
@@ -47,16 +47,6 @@ class MaxActiveRunsValidationRule(BaseRule):
 
         return issues
 
-    def _is_dag_call(self, node: ast.Call) -> bool:
-        """Check if a call is a DAG instantiation."""
-        if isinstance(node.func, ast.Name):
-            return node.func.id == "DAG"
-
-        if isinstance(node.func, ast.Attribute):
-            return node.func.attr == "DAG"
-
-        return False
-
     def _extract_max_active_runs(self, node: ast.Call) -> Optional[int]:
         """Extract max_active_runs from a DAG() call."""
         for keyword in node.keywords:

--- a/src/daglint/rules/metadata/owner_validation.py
+++ b/src/daglint/rules/metadata/owner_validation.py
@@ -1,7 +1,7 @@
 """Rule for validating DAG owner."""
 
 import ast
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 from daglint.models import LintIssue
 from daglint.rules.base import BaseRule
@@ -22,47 +22,52 @@ class OwnerValidationRule(BaseRule):
         issues = []
         valid_owners = self.config.get("valid_owners", [])
 
-        for node in ast.walk(tree):
-            if isinstance(node, ast.Dict):
-                # Check if this is a default_args dictionary
-                owner_value = self._extract_owner_from_dict(node)
-                if owner_value is not None:
-                    if not owner_value:
-                        issues.append(
-                            self.create_issue(
-                                "DAG owner must be specified",
-                                file_path,
-                                node.lineno,
-                                node.col_offset,
-                            )
-                        )
-                    elif valid_owners and owner_value not in valid_owners:
-                        issues.append(
-                            self.create_issue(
-                                f"Invalid owner '{owner_value}'. Must be one of: {', '.join(valid_owners)}",
-                                file_path,
-                                node.lineno,
-                                node.col_offset,
-                            )
-                        )
-                else:
-                    # Owner key is missing
-                    issues.append(
-                        self.create_issue(
-                            "DAG owner must be specified",
-                            file_path,
-                            node.lineno,
-                            node.col_offset,
-                        )
+        for node in self._find_default_args_dicts(tree):
+            has_owner_key, owner_value = self._extract_owner_from_dict(node)
+            if not has_owner_key:
+                issues.append(
+                    self.create_issue(
+                        "DAG owner must be specified",
+                        file_path,
+                        node.lineno,
+                        node.col_offset,
                     )
+                )
+            elif owner_value is None:
+                # Owner is present but not a static string (e.g. a variable
+                # or Variable.get(...)); cannot validate, so skip.
+                continue
+            elif not owner_value:
+                issues.append(
+                    self.create_issue(
+                        "DAG owner must be specified",
+                        file_path,
+                        node.lineno,
+                        node.col_offset,
+                    )
+                )
+            elif valid_owners and owner_value not in valid_owners:
+                issues.append(
+                    self.create_issue(
+                        f"Invalid owner '{owner_value}'. Must be one of: {', '.join(valid_owners)}",
+                        file_path,
+                        node.lineno,
+                        node.col_offset,
+                    )
+                )
 
         return issues
 
-    def _extract_owner_from_dict(self, node: ast.Dict) -> Optional[str]:
-        """Extract owner value from a dictionary node."""
+    def _extract_owner_from_dict(self, node: ast.Dict) -> Tuple[bool, Optional[str]]:
+        """Extract the owner entry from a default_args dictionary node.
+
+        Returns:
+            Tuple of (owner key present, owner value). The value is None
+            when the key is absent or its value is not a static string.
+        """
         for key, value in zip(node.keys, node.values):
             if isinstance(key, ast.Constant) and key.value == "owner":
-                if isinstance(value, ast.Constant):
-                    if isinstance(value.value, str):
-                        return value.value
-        return None
+                if isinstance(value, ast.Constant) and isinstance(value.value, str):
+                    return True, value.value
+                return True, None
+        return False, None

--- a/tests/rules/test_owner_validation.py
+++ b/tests/rules/test_owner_validation.py
@@ -70,8 +70,8 @@ default_args = {
         issues = rule.check(tree, "test.py", code)
         assert len(issues) == 0
 
-    def test_multiple_dicts_with_owners(self):
-        """Test that multiple dictionaries with owner keys are validated."""
+    def test_non_default_args_dicts_ignored(self):
+        """Test that dicts other than default_args are not inspected at all."""
         code = """
 default_args = {
     'owner': 'data-team'
@@ -84,8 +84,112 @@ other_args = {
         tree = ast.parse(code)
         rule = OwnerValidationRule({"valid_owners": ["data-team", "analytics-team"]})
         issues = rule.check(tree, "test.py", code)
+        assert len(issues) == 0
+
+    def test_op_kwargs_dict_not_flagged(self):
+        """Regression test: op_kwargs dicts must not trigger owner errors (#31)."""
+        code = """
+default_args = {
+    'owner': 'data-team'
+}
+
+t1 = PythonOperator(
+    task_id="do_thing",
+    python_callable=my_func,
+    op_kwargs={"foo": 1, "bar": 2},
+)
+"""
+        tree = ast.parse(code)
+        rule = OwnerValidationRule({"valid_owners": ["data-team", "analytics-team"]})
+        issues = rule.check(tree, "test.py", code)
+        assert len(issues) == 0
+
+    def test_params_dict_not_flagged(self):
+        """Regression test: params dicts must not trigger owner errors (#31)."""
+        code = """
+default_args = {
+    'owner': 'data-team'
+}
+
+dag = DAG(
+    dag_id="my_dag",
+    default_args=default_args,
+    params={"env": "prod", "retries": 3},
+)
+"""
+        tree = ast.parse(code)
+        rule = OwnerValidationRule({"valid_owners": ["data-team", "analytics-team"]})
+        issues = rule.check(tree, "test.py", code)
+        assert len(issues) == 0
+
+    def test_inline_default_args_valid_owner(self):
+        """Test that default_args passed inline to DAG() is validated."""
+        code = """
+dag = DAG(
+    dag_id="my_dag",
+    default_args={'owner': 'data-team'},
+)
+"""
+        tree = ast.parse(code)
+        rule = OwnerValidationRule({"valid_owners": ["data-team", "analytics-team"]})
+        issues = rule.check(tree, "test.py", code)
+        assert len(issues) == 0
+
+    def test_inline_default_args_invalid_owner(self):
+        """Test that invalid owners in inline default_args are caught."""
+        code = """
+dag = DAG(
+    dag_id="my_dag",
+    default_args={'owner': 'invalid-team'},
+)
+"""
+        tree = ast.parse(code)
+        rule = OwnerValidationRule({"valid_owners": ["data-team", "analytics-team"]})
+        issues = rule.check(tree, "test.py", code)
         assert len(issues) == 1
         assert "Invalid owner 'invalid-team'" in issues[0].message
+
+    def test_inline_default_args_missing_owner(self):
+        """Test that a missing owner key in inline default_args is caught."""
+        code = """
+dag = DAG(
+    dag_id="my_dag",
+    default_args={'retries': 2},
+)
+"""
+        tree = ast.parse(code)
+        rule = OwnerValidationRule({"valid_owners": ["data-team", "analytics-team"]})
+        issues = rule.check(tree, "test.py", code)
+        assert len(issues) == 1
+        assert "DAG owner must be specified" in issues[0].message
+
+    def test_dynamic_owner_value_skipped(self):
+        """Test that a non-literal owner value is skipped, not flagged."""
+        code = """
+default_args = {
+    'owner': OWNER_CONST
+}
+"""
+        tree = ast.parse(code)
+        rule = OwnerValidationRule({"valid_owners": ["data-team", "analytics-team"]})
+        issues = rule.check(tree, "test.py", code)
+        assert len(issues) == 0
+
+    def test_no_default_args_no_issues(self):
+        """Test that a file without default_args produces no owner issues."""
+        code = """
+dag = DAG(dag_id="my_dag")
+
+t1 = PythonOperator(
+    task_id="do_thing",
+    python_callable=my_func,
+    op_kwargs={"foo": 1},
+)
+"""
+        tree = ast.parse(code)
+        rule = OwnerValidationRule({"valid_owners": ["data-team", "analytics-team"]})
+        issues = rule.check(tree, "test.py", code)
+        assert len(issues) == 0
 
     def test_rule_has_metadata(self):
         """Test that rule has required metadata."""

--- a/tests/rules/test_owner_validation.py
+++ b/tests/rules/test_owner_validation.py
@@ -163,6 +163,35 @@ dag = DAG(
         assert len(issues) == 1
         assert "DAG owner must be specified" in issues[0].message
 
+    def test_non_dag_call_with_default_args_kwarg_ignored(self):
+        """Regression test: default_args kwargs on non-DAG calls are not inspected."""
+        code = """
+default_args = {
+    'owner': 'data-team'
+}
+
+with TaskGroup("group", default_args={'retries': 1}):
+    pass
+"""
+        tree = ast.parse(code)
+        rule = OwnerValidationRule({"valid_owners": ["data-team", "analytics-team"]})
+        issues = rule.check(tree, "test.py", code)
+        assert len(issues) == 0
+
+    def test_attribute_dag_call_inline_default_args_validated(self):
+        """Test that models.DAG(default_args={...}) is still validated."""
+        code = """
+dag = models.DAG(
+    dag_id="my_dag",
+    default_args={'retries': 2},
+)
+"""
+        tree = ast.parse(code)
+        rule = OwnerValidationRule({"valid_owners": ["data-team", "analytics-team"]})
+        issues = rule.check(tree, "test.py", code)
+        assert len(issues) == 1
+        assert "DAG owner must be specified" in issues[0].message
+
     def test_dynamic_owner_value_skipped(self):
         """Test that a non-literal owner value is skipped, not flagged."""
         code = """


### PR DESCRIPTION
## Summary

`OwnerValidationRule` walked **every** `ast.Dict` in the file and flagged any dict without an `"owner"` key, so ordinary dict literals (`op_kwargs`, `params`, template dicts) produced false `DAG owner must be specified` errors.

This PR scopes the rule to `default_args` dicts only, per the refined acceptance criteria in #31:

- New `BaseRule._find_default_args_dicts` helper matches both `default_args = {...}` assignments and inline `DAG(default_args={...})` keywords. It lives on `BaseRule` so #41 (required_dag_params parity) can reuse it.
- `_extract_owner_from_dict` now returns a `(key_present, value)` pair, distinguishing "owner key absent" from "owner value not a static string". Dynamic owners (`'owner': OWNER_CONST`, `Variable.get(...)`) are skipped instead of misreported as missing — the second false-positive class identified during refinement.
- Intentional behavior change: non-`default_args` dicts are no longer inspected at all, even when they contain an invalid `owner` value. `test_multiple_dicts_with_owners` was rewritten as `test_non_default_args_dicts_ignored` accordingly.

## Verification (end-to-end via CLI)

Before fix, the issue's repro (compliant DAG + `op_kwargs={"foo": 1, "bar": 2}`):

```
ERROR [owner_validation] Line 28: DAG owner must be specified   ← points at op_kwargs
```

After fix: no owner_validation issues on the repro. Also exercised via `daglint check`:

- inline `DAG(default_args={'retries': 2})` → `ERROR ... DAG owner must be specified` ✅
- inline `default_args={'owner': 'rogue-team'}` with `valid_owners` configured → `Invalid owner 'rogue-team'. Must be one of: ...` ✅
- `'owner': OWNER` (dynamic) → no owner issue ✅
- `default_args = {'owner': ''}` → flagged ✅
- assignment + a *different* inline default_args in one file → both inspected, only the invalid one flagged ✅

## Tests

- Regression tests for `op_kwargs`/`params` dicts in otherwise-valid DAGs
- Inline `DAG(default_args={...})`: valid / invalid / missing owner
- Dynamic owner value skipped; file with no `default_args` at all produces no issues
- `make check` green (101 passed, owner_validation at 100% coverage)

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)
