### PR TITLE
ci: make quality gates actually fail the build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,23 +42,19 @@ jobs:
 
     - name: Run linting with flake8
       run: |
-        flake8 src/daglint --count --select=E9,F63,F7,F82 --show-source --statistics
-        flake8 src/daglint --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        flake8 src/daglint --count --statistics
 
     - name: Run type checking with mypy
       run: |
         mypy src/daglint --ignore-missing-imports
-      continue-on-error: true
 
     - name: Check code formatting with black
       run: |
         black --check src/daglint tests
-      continue-on-error: true
 
     - name: Check import sorting with isort
       run: |
         isort --check-only src/daglint tests
-      continue-on-error: true
 
     - name: Run tests with pytest
       run: |

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -33,18 +33,11 @@ jobs:
       run: |
         pytest tests/ -v --cov=daglint --cov-report=term
 
-    - name: Check test results
-      if: failure()
-      run: |
-        echo "Tests failed! Please fix the failing tests before merging."
-        exit 1
-
     - name: Verify code quality
       run: |
-        flake8 src/daglint --count --max-line-length=127 --statistics
+        flake8 src/daglint --count --statistics
         black --check src/daglint tests
         isort --check-only src/daglint tests
-      continue-on-error: true
 
     - name: Comment PR with test results
       if: always()

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -15,10 +15,13 @@ The CI pipeline will automatically:
 
 ### Pull Request Requirements
 For a PR to be merged, it must:
-- ✅ Pass all tests
-- ✅ Maintain or improve code coverage
-- ✅ Pass all linting checks
-- ✅ Be formatted correctly
+- ✅ Pass all tests on Python 3.10, 3.11, and 3.12
+- ✅ Pass linting (flake8) and type checking (mypy)
+- ✅ Be formatted correctly (black, isort)
+
+All of these are enforced by CI — any failure blocks the merge. Coverage is
+reported on every run but not currently gated. Run `make check` locally to
+run the identical gates before pushing.
 
 ## Using DAGLint in Your Airflow Project
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL := help
 
-.PHONY: help install install-dev test test-cov lint format clean build check all
+.PHONY: help install install-dev test test-cov lint format format-check clean build check all
 
 BLUE := \033[0;34m
 GREEN := \033[0;32m
@@ -34,11 +34,12 @@ help:
 	@printf "    install-dev   Install package with dev dependencies\n"
 	@printf "    test          Run tests\n"
 	@printf "    test-cov      Run tests with coverage\n"
-	@printf "    lint          Run linting checks\n"
+	@printf "    lint          Run linting checks (flake8 + mypy)\n"
 	@printf "    format        Format code with black and isort\n"
+	@printf "    format-check  Check formatting without modifying files\n"
 	@printf "    clean         Clean build artifacts\n"
 	@printf "    build         Build package\n"
-	@printf "    check         Run all quality checks (lint + test)\n"
+	@printf "    check         Run all quality checks (format-check + lint + test)\n"
 	@printf "    all           Install dev deps, format, lint, and test\n\n"
 	@printf "$(GREEN)Examples:$(NC)\n"
 	@printf "    make install-dev    # Install with dev dependencies\n"
@@ -72,22 +73,18 @@ lint:
 	@$(call print_status,Running flake8...)
 	@flake8 src/daglint
 	@$(call print_success,flake8 passed)
+	@$(call print_status,Running type checks with mypy...)
+	@mypy src/daglint --ignore-missing-imports
+	@$(call print_success,mypy check passed)
+	@$(call print_success,All linting checks completed)
+
+format-check:
 	@$(call print_status,Checking code formatting with black...)
 	@black --check src/daglint tests
 	@$(call print_success,black check passed)
 	@$(call print_status,Checking import sorting with isort...)
 	@isort --check-only src/daglint tests
 	@$(call print_success,isort check passed)
-	@$(call print_status,Running type checks with mypy...)
-	@set +e; \
-	mypy src/daglint --ignore-missing-imports; \
-	status=$$?; \
-	if [ $$status -eq 0 ]; then \
-		$(call print_success,mypy check passed); \
-	else \
-		$(call print_warning,mypy check completed with warnings); \
-	fi
-	@$(call print_success,All linting checks completed)
 
 format:
 	@$(call print_status,Formatting code with black...)
@@ -112,7 +109,7 @@ build: clean
 
 check:
 	@$(call print_status,Running all quality checks...)
-	@$(MAKE) format
+	@$(MAKE) format-check
 	@$(MAKE) lint
 	@$(MAKE) test
 	@$(call print_success,All checks passed! 🎉)


### PR DESCRIPTION
## Summary

CI quality gates could not fail: mypy/black/isort steps in `ci.yml` had `continue-on-error: true`, the second flake8 pass used `--exit-zero`, the entire quality step in `pr-checks.yml` was `continue-on-error: true`, and `make check` ran `format` (mutating files) instead of checking. DEPLOYMENT.md promised enforcement that didn't exist.

Per the refined acceptance criteria in #36:

- **ci.yml** — `continue-on-error` removed from mypy, black, and isort steps. The two-pass flake8 (gating E9/F63/F7/F82 subset + `--exit-zero --max-line-length=127` advisory pass) is now a single gating run on the project `.flake8` config (which already sets max-complexity and line length).
- **pr-checks.yml** — `continue-on-error` removed from "Verify code quality"; flake8 uses project config instead of a hardcoded `--max-line-length=127`; the redundant "Check test results" step (`if: failure()` → `exit 1`) is deleted since failing steps now fail the job on their own.
- **Makefile** — new `format-check` target (`black --check` + `isort --check-only`); `lint` is now flake8 + mypy and **fails** on mypy errors (warning-downgrade wrapper removed); `make check` runs `format-check` + `lint` + `test` and never mutates files. Help text and `.PHONY` updated.
- **DEPLOYMENT.md** — PR requirements now describe exactly what CI enforces; the "maintain or improve coverage" bullet is gone (coverage is reported, not gated — no `fail-under` is configured).

mypy passes clean on the current tree (`Success: no issues found in 16 source files`), so it gates immediately — no advisory period.

Note: the project line length is 127 (consistent across `.flake8`, black, and isort in pyproject). This PR only removes ad-hoc flag duplication; changing the standard is a separate decision.

## Verification

- `make check` on the clean tree: all gates green, 103 tests pass.
- Failure path (formatting): appended a misformatted line to `tests/test_linter.py` → `make check` exits 2 and the file is **byte-identical** afterwards (shasum before/after) — the mutation bug is gone.
- Failure path (types): appended `bad_type: int = "not an int"` to `src/daglint/models.py` → `make lint` exits 2.
- Both workflow files parse as valid YAML.
- This PR's own CI run is the live proof the gates execute and pass on a compliant branch.

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)
