### PR TITLE
fix: reject unknown --rules names instead of silently passing

### DIFF
--- a/src/daglint/cli.py
+++ b/src/daglint/cli.py
@@ -79,8 +79,15 @@ def check(path: str, config: Optional[str], rules: Optional[str], verbose: bool,
 
     # Override rules if specified
     if rules:
-        rule_list = [r.strip() for r in rules.split(",")]
-        cfg.set_active_rules(rule_list)
+        rule_list = [r.strip() for r in rules.split(",") if r.strip()]
+        if not rule_list:
+            raise click.UsageError("--rules was given but contains no rule names")
+        unknown = [r for r in rule_list if r not in AVAILABLE_RULES]
+        if unknown:
+            raise click.UsageError(
+                f"Unknown rule(s): {', '.join(unknown)}. " f"Valid rules are: {', '.join(sorted(AVAILABLE_RULES))}"
+            )
+        cfg.set_active_rules(rule_list, all_rule_ids=list(AVAILABLE_RULES))
 
     # Collect files to lint
     files_to_check = _collect_files(target_path)

--- a/src/daglint/cli.py
+++ b/src/daglint/cli.py
@@ -78,7 +78,7 @@ def check(path: str, config: Optional[str], rules: Optional[str], verbose: bool,
     cfg = _load_config(config)
 
     # Override rules if specified
-    if rules:
+    if rules is not None:
         rule_list = [r.strip() for r in rules.split(",") if r.strip()]
         if not rule_list:
             raise click.UsageError("--rules was given but contains no rule names")

--- a/src/daglint/config.py
+++ b/src/daglint/config.py
@@ -121,14 +121,19 @@ class Config:
         rule_config = self.get_rule_config(rule_id)
         return bool(rule_config.get("enabled", True))
 
-    def set_active_rules(self, rule_ids: List[str]) -> None:
-        """Enable only specified rules.
+    def set_active_rules(self, rule_ids: List[str], all_rule_ids: Optional[List[str]] = None) -> None:
+        """Enable only the specified rules, disabling all others.
 
         Args:
             rule_ids: List of rule IDs to enable
+            all_rule_ids: Full universe of known rule IDs. Rules listed here
+                but absent from the loaded config get an explicit disabled
+                entry, so a partial config file cannot leave them enabled
+                by default.
         """
-        for rule_id in self.rules_config:
-            self.rules_config[rule_id]["enabled"] = rule_id in rule_ids
+        universe = set(self.rules_config) | set(rule_ids) | set(all_rule_ids or [])
+        for rule_id in universe:
+            self.rules_config.setdefault(rule_id, {})["enabled"] = rule_id in rule_ids
 
     @staticmethod
     def generate_default_config(output_path: str) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -183,11 +183,11 @@ dag = DAG('InvalidDAGID')
         f.write(code)
         f.flush()
 
-        result = runner.invoke(cli, ["check", f.name, "--rules", ","])
+        for empty_value in (",", ""):
+            result = runner.invoke(cli, ["check", f.name, "--rules", empty_value])
+            assert result.exit_code == 2
+            assert "All checks passed" not in result.output
         Path(f.name).unlink()
-
-        assert result.exit_code == 2
-        assert "All checks passed" not in result.output
 
 
 def test_check_rules_with_partial_config_disables_unlisted_rules():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -106,6 +106,118 @@ dag = DAG('InvalidDAGID')
         assert result.exit_code == 1
 
 
+def test_check_unknown_rule_is_usage_error():
+    """An unknown rule name must abort with an error, not silently pass (#32)."""
+    code = """
+from airflow import DAG
+
+dag = DAG('InvalidDAGID')
+"""
+
+    runner = CliRunner()
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
+        f.write(code)
+        f.flush()
+
+        result = runner.invoke(cli, ["check", f.name, "--rules", "bogus_rule_name"])
+        Path(f.name).unlink()
+
+        assert result.exit_code == 2
+        assert "bogus_rule_name" in result.output
+        assert "owner_validation" in result.output  # valid rules are listed
+        assert "All checks passed" not in result.output
+
+
+def test_check_multiple_unknown_rules_all_reported():
+    """Every unknown rule name is reported in a single error, and nothing runs."""
+    code = """
+from airflow import DAG
+
+dag = DAG('InvalidDAGID')
+"""
+
+    runner = CliRunner()
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
+        f.write(code)
+        f.flush()
+
+        result = runner.invoke(cli, ["check", f.name, "--rules", "typo_one,dag_id_convention,typo_two"])
+        Path(f.name).unlink()
+
+        assert result.exit_code == 2
+        assert "typo_one" in result.output
+        assert "typo_two" in result.output
+        assert "does not match pattern" not in result.output  # no partial run
+
+
+def test_check_rules_trailing_comma_accepted():
+    """Trailing commas and whitespace in --rules are tolerated."""
+    code = """
+from airflow import DAG
+
+dag = DAG('InvalidDAGID')
+"""
+
+    runner = CliRunner()
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
+        f.write(code)
+        f.flush()
+
+        result = runner.invoke(cli, ["check", f.name, "--rules", "dag_id_convention, "])
+        Path(f.name).unlink()
+
+        assert result.exit_code == 1
+        assert "does not match pattern" in result.output
+
+
+def test_check_rules_with_only_separators_is_usage_error():
+    """--rules with no actual rule names must error, not lint with zero rules."""
+    code = """
+from airflow import DAG
+
+dag = DAG('InvalidDAGID')
+"""
+
+    runner = CliRunner()
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
+        f.write(code)
+        f.flush()
+
+        result = runner.invoke(cli, ["check", f.name, "--rules", ","])
+        Path(f.name).unlink()
+
+        assert result.exit_code == 2
+        assert "All checks passed" not in result.output
+
+
+def test_check_rules_with_partial_config_disables_unlisted_rules():
+    """--rules disables rules absent from a partial config file (#32)."""
+    code = """
+from airflow import DAG
+
+default_args = {}
+
+dag = DAG('my_dag', default_args=default_args)
+"""
+
+    runner = CliRunner()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        dag_file = Path(tmpdir) / "my_dag.py"
+        dag_file.write_text(code)
+        config_file = Path(tmpdir) / "partial.yaml"
+        config_file.write_text("rules:\n  dag_id_convention:\n    enabled: true\n")
+
+        # owner_validation would flag the empty default_args, but it is not
+        # in the requested rules, so it must stay disabled.
+        result = runner.invoke(
+            cli,
+            ["check", str(dag_file), "--config", str(config_file), "--rules", "dag_id_convention"],
+        )
+
+        assert result.exit_code == 0
+        assert "All checks passed" in result.output
+
+
 def test_check_verbose():
     """Test verbose output."""
     code = """

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -64,6 +64,26 @@ def test_set_active_rules():
     assert not config.is_rule_enabled("task_id_convention")
 
 
+def test_set_active_rules_is_authoritative():
+    """After set_active_rules, exactly the requested rules are enabled (#32)."""
+    config = Config.default()
+    config.set_active_rules(["owner_validation"], all_rule_ids=list(AVAILABLE_RULES))
+
+    for rule_id in AVAILABLE_RULES:
+        assert config.is_rule_enabled(rule_id) == (rule_id == "owner_validation")
+
+
+def test_set_active_rules_disables_rules_missing_from_partial_config():
+    """Rules absent from a partial config get an explicit disabled entry (#32)."""
+    config = Config({"rules": {"dag_id_convention": {"enabled": True}}})
+    config.set_active_rules(["dag_id_convention"], all_rule_ids=list(AVAILABLE_RULES))
+
+    assert config.is_rule_enabled("dag_id_convention")
+    for rule_id in AVAILABLE_RULES:
+        if rule_id != "dag_id_convention":
+            assert not config.is_rule_enabled(rule_id)
+
+
 def test_generate_default_config():
     """Test generating default configuration file."""
     with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary

`daglint check <path> --rules <typo>` silently disabled every rule and reported "All checks passed!" with exit 0 — a green build on broken DAGs. Two bugs in the same path, both fixed per the refined acceptance criteria in #32:

- **`cli.py`**: `--rules` names are now validated against `AVAILABLE_RULES` before any linting runs. Any unknown name aborts with a usage error (exit **2**, distinct from exit 1 = lint issues) that names **all** unknown tokens and lists the valid rule IDs. Mixed valid + unknown is an error, never a partial run. Empty tokens are stripped, so `--rules "owner_validation, "` works; `--rules ","` (no actual names) is also a usage error rather than a zero-rule "pass" — same silent-nothing failure mode, so it's guarded even though the refinement didn't explicitly call it out.
- **`config.py`**: `set_active_rules` was only authoritative over rules already present in the loaded config, so with a partial config file, unlisted rules stayed enabled via `is_rule_enabled`'s default. It now takes an `all_rule_ids` universe (passed from the CLI, keeping `config` decoupled from `rules`) and writes an explicit enabled/disabled entry for every known rule.

## Verification (end-to-end via CLI)

The issue's repro:

```
$ daglint check examples/invalid_dag.py --rules bogus_rule_name
Error: Unknown rule(s): bogus_rule_name. Valid rules are: catchup_validation, dag_id_convention, ...
exit=2
```

Regressions: `--rules owner_validation` on the same file → 1 issue, exit 1; no `--rules` → 11 issues, exit 1.

## Tests

- Unknown rule → exit 2, error names it, valid IDs listed, no "All checks passed"
- Multiple unknowns all reported in one error, no partial run
- Trailing comma/whitespace accepted; separator-only `--rules` rejected
- Partial config + `--rules` disables unlisted rules (CLI end-to-end with a config file)
- `Config` unit tests: after `set_active_rules`, exactly the requested rules are enabled across the full `AVAILABLE_RULES` universe, including from a partial config
- `make check` green (110 passed)

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)
