### PR TITLE
fix: remove no-op --fix flag from daglint check

### DIFF
--- a/src/daglint/cli.py
+++ b/src/daglint/cli.py
@@ -66,8 +66,7 @@ def _print_summary(total_issues: int, file_count: int):
 @click.option("--config", "-c", type=click.Path(exists=True), help="Path to configuration file")
 @click.option("--rules", "-r", help="Comma-separated list of rules to check")
 @click.option("--verbose", "-v", is_flag=True, help="Verbose output")
-@click.option("--fix", is_flag=True, help="Automatically fix issues where possible")
-def check(path: str, config: Optional[str], rules: Optional[str], verbose: bool, fix: bool):
+def check(path: str, config: Optional[str], rules: Optional[str], verbose: bool):
     """Check DAG files for linting issues.
 
     PATH can be a single file or a directory containing DAG files.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -238,7 +238,7 @@ dag = DAG('my_dag')
 
 
 def test_check_help_does_not_advertise_fix():
-    """--fix was a no-op flag; it must not appear in help until implemented (#35)."""
+    """--fix is gone for good (autofix is out of scope); help must not mention it (#35)."""
     runner = CliRunner()
     result = runner.invoke(cli, ["check", "--help"])
     assert result.exit_code == 0
@@ -256,13 +256,13 @@ dag = DAG('my_dag')
     runner = CliRunner()
     with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
         f.write(code)
-        f.flush()
-
+    try:
         result = runner.invoke(cli, ["check", f.name, "--fix"])
+    finally:
         Path(f.name).unlink()
 
-        assert result.exit_code == 2
-        assert "No such option" in result.output
+    assert result.exit_code == 2
+    assert "No such option" in result.output
 
 
 def test_rules_command():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -237,6 +237,34 @@ dag = DAG('my_dag')
         assert "Checking:" in result.output
 
 
+def test_check_help_does_not_advertise_fix():
+    """--fix was a no-op flag; it must not appear in help until implemented (#35)."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["check", "--help"])
+    assert result.exit_code == 0
+    assert "--fix" not in result.output
+
+
+def test_check_fix_flag_rejected():
+    """Passing the removed --fix flag is a usage error, not a silent no-op (#35)."""
+    code = """
+from airflow import DAG
+
+dag = DAG('my_dag')
+"""
+
+    runner = CliRunner()
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
+        f.write(code)
+        f.flush()
+
+        result = runner.invoke(cli, ["check", f.name, "--fix"])
+        Path(f.name).unlink()
+
+        assert result.exit_code == 2
+        assert "No such option" in result.output
+
+
 def test_rules_command():
     """Test rules command."""
     runner = CliRunner()


### PR DESCRIPTION
## Summary

`daglint check` advertised `--fix` ("Automatically fix issues where possible") in `--help`, but the parameter was never read — the flag was accepted and silently ignored, leaving users believing their files had been fixed.

Per the refined decision in #35: **autofix will not be added to daglint** (it stays a pure linter), so the flag is removed outright — no stub, no tracking issue.

- `--fix` option and the dead `fix` parameter removed from `check` in `src/daglint/cli.py` (its only two occurrences in the repo; no docs referenced it).
- Deliberate behavior change: `daglint check <path> --fix` now fails with click's "No such option '--fix'. Did you mean '--config'?" usage error (exit 2). For any pipeline that was passing `--fix`, a loud failure is the correct outcome — it was never fixing anything.

## Verification (end-to-end via CLI)

- `daglint check examples/valid_dag.py --fix` → "No such option '--fix'", exit 2
- `daglint check --help` → no mention of `--fix`

## Tests

- Help output does not advertise `--fix`
- Passing `--fix` exits 2 with "No such option"
- `make check` green (112 passed)

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)
