### PR TITLE
feat: check inline DAG(default_args={...}) in required_dag_params

### DIFF
--- a/src/daglint/rules/metadata/required_dag_params.py
+++ b/src/daglint/rules/metadata/required_dag_params.py
@@ -22,23 +22,18 @@ class RequiredDAGParamsRule(BaseRule):
         issues = []
         required_params = self.config.get("required_params", ["owner", "start_date", "description"])
 
-        for node in ast.walk(tree):
-            # Check default_args dict
-            if isinstance(node, ast.Assign):
-                for target in node.targets:
-                    if isinstance(target, ast.Name) and target.id == "default_args":
-                        if isinstance(node.value, ast.Dict):
-                            present_params = self._extract_dict_keys(node.value)
-                            missing_params = set(required_params) - set(present_params)
-                            if missing_params:
-                                issues.append(
-                                    self.create_issue(
-                                        f"Missing required parameters in default_args: {', '.join(missing_params)}",
-                                        file_path,
-                                        node.lineno,
-                                        node.col_offset,
-                                    )
-                                )
+        for node in self._find_default_args_dicts(tree):
+            present_params = self._extract_dict_keys(node)
+            missing_params = set(required_params) - set(present_params)
+            if missing_params:
+                issues.append(
+                    self.create_issue(
+                        f"Missing required parameters in default_args: {', '.join(sorted(missing_params))}",
+                        file_path,
+                        node.lineno,
+                        node.col_offset,
+                    )
+                )
 
         return issues
 

--- a/tests/rules/test_required_dag_params.py
+++ b/tests/rules/test_required_dag_params.py
@@ -153,6 +153,79 @@ default_args = {
         assert len(issues) == 1
         assert "Missing required parameters" in issues[0].message
 
+    def test_inline_default_args_missing_params(self):
+        """Test that inline DAG(default_args={...}) missing params is caught (#41)."""
+        code = """
+dag = DAG(
+    dag_id='my_dag',
+    default_args={'owner': 'airflow'},
+)
+"""
+        tree = ast.parse(code)
+        rule = RequiredDAGParamsRule({"required_params": ["owner", "start_date", "retries"]})
+        issues = rule.check(tree, "test.py", code)
+        assert len(issues) == 1
+        assert "Missing required parameters in default_args: retries, start_date" in issues[0].message
+
+    def test_inline_default_args_all_params_present(self):
+        """Test that inline default_args with all required params passes (#41)."""
+        code = """
+dag = DAG(
+    dag_id='my_dag',
+    default_args={'owner': 'airflow', 'start_date': '2023-01-01', 'retries': 3},
+)
+"""
+        tree = ast.parse(code)
+        rule = RequiredDAGParamsRule({"required_params": ["owner", "start_date", "retries"]})
+        issues = rule.check(tree, "test.py", code)
+        assert len(issues) == 0
+
+    def test_assignment_and_inline_forms_both_checked(self):
+        """Test that assignment and a separate inline default_args are each validated."""
+        code = """
+default_args = {
+    'owner': 'airflow',
+    'start_date': '2023-01-01'
+}
+
+dag = DAG(
+    dag_id='my_dag',
+    default_args={'owner': 'airflow'},
+)
+"""
+        tree = ast.parse(code)
+        rule = RequiredDAGParamsRule({"required_params": ["owner", "start_date"]})
+        issues = rule.check(tree, "test.py", code)
+        assert len(issues) == 1
+        assert "start_date" in issues[0].message
+
+    def test_non_dag_call_default_args_ignored(self):
+        """Test that default_args kwargs on non-DAG calls are not inspected."""
+        code = """
+default_args = {
+    'owner': 'airflow',
+    'start_date': '2023-01-01'
+}
+
+with TaskGroup('group', default_args={'retries': 1}):
+    pass
+"""
+        tree = ast.parse(code)
+        rule = RequiredDAGParamsRule({"required_params": ["owner", "start_date"]})
+        issues = rule.check(tree, "test.py", code)
+        assert len(issues) == 0
+
+    def test_missing_params_listed_in_sorted_order(self):
+        """Missing params are reported in deterministic (sorted) order."""
+        code = """
+default_args = {}
+"""
+        tree = ast.parse(code)
+        rule = RequiredDAGParamsRule({"required_params": ["start_date", "owner", "retries"]})
+        issues = rule.check(tree, "test.py", code)
+        assert len(issues) == 1
+        assert "Missing required parameters in default_args: owner, retries, start_date" in issues[0].message
+
     def test_rule_has_metadata(self):
         """Test that rule has required metadata."""
         rule = RequiredDAGParamsRule()


### PR DESCRIPTION
## Summary

`RequiredDAGParamsRule` only matched the assignment form (`default_args = {...}`), so a DAG passing `default_args={...}` inline to `DAG(...)` was never checked — missing required params went unreported.

Per the refined scope in #41:

- The rule now discovers `default_args` dicts through the shared `BaseRule._find_default_args_dicts` helper (built in #42 for `owner_validation`, DAG-call-gated). Both rules now recognize `default_args` identically: assignment form, inline form on DAG calls only, `default_args=` kwargs on non-DAG calls (e.g. `TaskGroup`) ignored.
- Missing params are reported in **sorted order** — the same set-join nondeterminism the #48 review caught in `tag_requirements` existed here; fixed while touching the line, with a test pinning the order.
- Issue position is now the `default_args` dict literal (what the helper returns) rather than the assignment statement — same line for the conventional layout, and for the inline form it points into the `DAG(...)` call.

## Verification (end-to-end via CLI)

```
$ daglint check inline_dag.py --rules required_dag_params
ERROR [required_dag_params] Line 3: Missing required parameters in default_args: retries, start_date
```

where `inline_dag.py` passes `default_args={"owner": "data-team"}` inline — previously silent.

## Tests

- Inline form: missing params flagged (sorted message), all-params-present clean
- Assignment + a different inline `default_args` in one file → each validated independently
- `TaskGroup(default_args={...})` ignored (helper's DAG gating)
- Sorted-order pin with a deliberately unsorted `required_params` config
- `make check` green (124 passed)

Out of scope, noted in the issue: files with no `default_args` at all still produce no issues (pre-existing, pinned by `test_no_default_args`), and the rule's fallback `required_params` default still disagrees with the default config (`description` vs `retries`) — pre-existing inconsistency, untouched here.

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)
