### PR TITLE
feat: TaskFlow @dag detection via shared DagDefinition layer (PR 1 of #34)

### DIFF
--- a/examples/invalid_taskflow_dag.py
+++ b/examples/invalid_taskflow_dag.py
@@ -1,0 +1,17 @@
+"""Example of a TaskFlow API DAG file with violations daglint should catch."""
+from airflow.decorators import dag, task
+
+
+@dag(schedule='@daily', default_args={'retries': 1})
+def InvalidTaskflowDAG():
+    """Bad pipeline: PascalCase name, missing catchup/tags/doc_md/max_active_runs,
+    default_args without owner/start_date."""
+
+    @task
+    def DoThing():
+        return 1
+
+    DoThing()
+
+
+InvalidTaskflowDAG()

--- a/examples/valid_dag.py
+++ b/examples/valid_dag.py
@@ -37,6 +37,11 @@ with DAG(
     max_active_runs=1,
     catchup=False,
     tags=['environment', 'team', 'example'],
+    doc_md="""
+    ### Example Valid DAG
+
+    Demonstrates the classic DAG style that daglint validates.
+    """,
 ) as dag:
 
     task_hello = PythonOperator(

--- a/examples/valid_taskflow_dag.py
+++ b/examples/valid_taskflow_dag.py
@@ -1,0 +1,52 @@
+"""Example of a valid TaskFlow API DAG file that passes all daglint checks."""
+from datetime import datetime, timedelta
+
+from airflow.decorators import dag, task
+
+default_args = {
+    'owner': 'data-team',
+    'depends_on_past': False,
+    'start_date': datetime(2023, 1, 1),
+    'email_on_failure': False,
+    'email_on_retry': False,
+    'retries': 3,
+    'retry_delay': timedelta(minutes=5),
+}
+
+
+@dag(
+    dag_id='valid_taskflow_dag',
+    default_args=default_args,
+    description='A valid TaskFlow DAG example',
+    schedule='@daily',
+    catchup=False,
+    max_active_runs=1,
+    tags=['environment', 'team'],
+    doc_md="""
+    ### Valid TaskFlow DAG
+
+    Demonstrates the TaskFlow API style that daglint validates.
+    """,
+)
+def valid_taskflow_dag():
+    """Define the pipeline using TaskFlow tasks."""
+
+    @task
+    def extract():
+        """Extract sample data."""
+        return {'value': 42}
+
+    @task
+    def transform(data):
+        """Transform the extracted data."""
+        return {'value': data['value'] * 2}
+
+    @task
+    def load(data):
+        """Load the transformed data."""
+        print(f"Loading: {data}")
+
+    load(transform(extract()))
+
+
+valid_taskflow_dag()

--- a/src/daglint/rules/base.py
+++ b/src/daglint/rules/base.py
@@ -7,6 +7,63 @@ from typing import Any, Dict, List, Optional
 from daglint.models import LintIssue
 
 
+class DagDefinition:
+    """A DAG defined either as a DAG(...) call or an @dag-decorated function.
+
+    Normalizes the two forms so rules can read DAG arguments and the
+    effective DAG ID without caring how the DAG was declared.
+    """
+
+    def __init__(
+        self,
+        call: Optional[ast.Call],
+        function_name: Optional[str] = None,
+        position: Optional[ast.expr] = None,
+    ):
+        """Initialize a DAG definition.
+
+        Args:
+            call: The DAG(...) call or @dag(...) decorator call; None for a
+                bare @dag decorator
+            function_name: Name of the decorated function (decorator form only)
+            position: Node to report issues at; defaults to the call
+        """
+        self.call = call
+        self.function_name = function_name
+        anchor = position if position is not None else call
+        self.lineno = anchor.lineno if anchor is not None else 0
+        self.col_offset = anchor.col_offset if anchor is not None else 0
+
+    def get_kwarg(self, name: str) -> Optional[ast.expr]:
+        """Return the AST value node for a keyword argument, if present.
+
+        Args:
+            name: Keyword argument name
+
+        Returns:
+            The value node, or None if the argument is absent
+        """
+        if self.call is None:
+            return None
+        for keyword in self.call.keywords:
+            if keyword.arg == name:
+                return keyword.value
+        return None
+
+    @property
+    def dag_id(self) -> Optional[str]:
+        """Effective DAG ID: explicit argument, else the decorated function name."""
+        if self.call is not None:
+            if self.call.args:
+                first = self.call.args[0]
+                if isinstance(first, ast.Constant) and isinstance(first.value, str):
+                    return first.value
+            value = self.get_kwarg("dag_id")
+            if isinstance(value, ast.Constant) and isinstance(value.value, str):
+                return value.value
+        return self.function_name
+
+
 class BaseRule(ABC):
     """Base class for all linting rules."""
 
@@ -92,37 +149,54 @@ class BaseRule(ABC):
                         return value
         return None
 
-    def _extract_dag_id(self, node: ast.Call) -> Optional[str]:
-        """Extract DAG ID from a DAG() call.
+    def _is_dag_decorator(self, node: ast.expr) -> bool:
+        """Check if a decorator node is an @dag decorator (bare or called).
 
         Args:
-            node: AST Call node representing a DAG instantiation
+            node: Entry from a FunctionDef's decorator_list
 
         Returns:
-            The dag_id string if found, None otherwise
+            True if the decorator is @dag, @dag(...), or @<module>.dag(...)
         """
-        # Check positional arguments
-        if node.args and isinstance(node.args[0], ast.Constant):
-            value = node.args[0].value
-            if isinstance(value, str):
-                return value
+        target = node.func if isinstance(node, ast.Call) else node
+        if isinstance(target, ast.Name):
+            return target.id == "dag"
+        elif isinstance(target, ast.Attribute):
+            return target.attr == "dag"
+        return False
 
-        # Check keyword arguments
-        for keyword in node.keywords:
-            if keyword.arg == "dag_id":
-                if isinstance(keyword.value, ast.Constant):
-                    value = keyword.value.value
-                    if isinstance(value, str):
-                        return value
+    def _find_dag_definitions(self, tree: ast.AST) -> List[DagDefinition]:
+        """Find every DAG definition in a file.
 
-        return None
+        Matches both declaration styles:
+            DAG(...) / <module>.DAG(...) instantiation calls
+            @dag / @dag(...) decorated functions (TaskFlow API)
+
+        Args:
+            tree: Abstract syntax tree of the file
+
+        Returns:
+            List of normalized DAG definitions
+        """
+        definitions = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call) and self._is_dag_call(node):
+                definitions.append(DagDefinition(call=node))
+            elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                for decorator in node.decorator_list:
+                    if self._is_dag_decorator(decorator):
+                        call = decorator if isinstance(decorator, ast.Call) else None
+                        definitions.append(DagDefinition(call=call, function_name=node.name, position=decorator))
+                        break
+        return definitions
 
     def _find_default_args_dicts(self, tree: ast.AST) -> List[ast.Dict]:
         """Find dict literals bound to default_args.
 
-        Matches both forms:
+        Matches all forms:
             default_args = {...}
             DAG(..., default_args={...})
+            @dag(default_args={...})
 
         Args:
             tree: Abstract syntax tree of the file
@@ -137,10 +211,10 @@ class BaseRule(ABC):
                     isinstance(target, ast.Name) and target.id == "default_args" for target in node.targets
                 ):
                     dicts.append(node.value)
-            elif isinstance(node, ast.Call) and self._is_dag_call(node):
-                for keyword in node.keywords:
-                    if keyword.arg == "default_args" and isinstance(keyword.value, ast.Dict):
-                        dicts.append(keyword.value)
+        for definition in self._find_dag_definitions(tree):
+            value = definition.get_kwarg("default_args")
+            if isinstance(value, ast.Dict):
+                dicts.append(value)
         return dicts
 
     def create_issue(self, message: str, file_path: str, line: int, column: int = 0) -> LintIssue:

--- a/src/daglint/rules/base.py
+++ b/src/daglint/rules/base.py
@@ -52,15 +52,23 @@ class DagDefinition:
 
     @property
     def dag_id(self) -> Optional[str]:
-        """Effective DAG ID: explicit argument, else the decorated function name."""
+        """Effective DAG ID: explicit argument, else the decorated function name.
+
+        Returns None when a dag_id argument is present but not a static
+        string — a dynamic ID overrides the function-name default in
+        Airflow, so nothing can be validated.
+        """
         if self.call is not None:
             if self.call.args:
                 first = self.call.args[0]
                 if isinstance(first, ast.Constant) and isinstance(first.value, str):
                     return first.value
+                return None
             value = self.get_kwarg("dag_id")
-            if isinstance(value, ast.Constant) and isinstance(value.value, str):
-                return value.value
+            if value is not None:
+                if isinstance(value, ast.Constant) and isinstance(value.value, str):
+                    return value.value
+                return None
         return self.function_name
 
 

--- a/src/daglint/rules/configuration.py
+++ b/src/daglint/rules/configuration.py
@@ -1,7 +1,7 @@
 """Rules for DAG configuration validation (retries, catchup, schedule)."""
 
 import ast
-from typing import Any, List, Optional
+from typing import List, Optional
 
 from daglint.models import LintIssue
 from daglint.rules.base import BaseRule
@@ -72,29 +72,24 @@ class CatchupValidationRule(BaseRule):
         issues = []
         default_catchup = self.config.get("default_catchup", False)
 
-        for node in ast.walk(tree):
-            if isinstance(node, ast.Call) and self._is_dag_call(node):
-                catchup_value = self._extract_catchup(node)
-                if catchup_value is None:
-                    issues.append(
-                        self.create_issue(
-                            f"Catchup parameter not set. Consider setting it explicitly to {default_catchup}",
-                            file_path,
-                            node.lineno,
-                            node.col_offset,
-                        )
+        for definition in self._find_dag_definitions(tree):
+            catchup_value = self._extract_catchup(definition.get_kwarg("catchup"))
+            if catchup_value is None:
+                issues.append(
+                    self.create_issue(
+                        f"Catchup parameter not set. Consider setting it explicitly to {default_catchup}",
+                        file_path,
+                        definition.lineno,
+                        definition.col_offset,
                     )
+                )
 
         return issues
 
-    def _extract_catchup(self, node: ast.Call) -> Optional[bool]:
-        """Extract catchup parameter from a DAG() call."""
-        for keyword in node.keywords:
-            if keyword.arg == "catchup":
-                if isinstance(keyword.value, ast.Constant):
-                    value = keyword.value.value
-                    if isinstance(value, bool):
-                        return value
+    def _extract_catchup(self, value: Optional[ast.expr]) -> Optional[bool]:
+        """Extract a boolean from a catchup argument value node."""
+        if isinstance(value, ast.Constant) and isinstance(value.value, bool):
+            return value.value
         return None
 
 
@@ -113,24 +108,16 @@ class ScheduleValidationRule(BaseRule):
         issues = []
         allow_none = self.config.get("allow_none", False)
 
-        for node in ast.walk(tree):
-            if isinstance(node, ast.Call) and self._is_dag_call(node):
-                schedule_value = self._extract_schedule(node)
-                if schedule_value is None and not allow_none:
-                    issues.append(
-                        self.create_issue(
-                            "schedule_interval must be explicitly set",
-                            file_path,
-                            node.lineno,
-                            node.col_offset,
-                        )
+        for definition in self._find_dag_definitions(tree):
+            schedule_value = definition.get_kwarg("schedule_interval") or definition.get_kwarg("schedule")
+            if schedule_value is None and not allow_none:
+                issues.append(
+                    self.create_issue(
+                        "schedule_interval must be explicitly set",
+                        file_path,
+                        definition.lineno,
+                        definition.col_offset,
                     )
+                )
 
         return issues
-
-    def _extract_schedule(self, node: ast.Call) -> Optional[Any]:
-        """Extract schedule_interval parameter from a DAG() call."""
-        for keyword in node.keywords:
-            if keyword.arg in ("schedule_interval", "schedule"):
-                return keyword.value
-        return None

--- a/src/daglint/rules/metadata/doc_md_validation.py
+++ b/src/daglint/rules/metadata/doc_md_validation.py
@@ -21,40 +21,38 @@ class DocMdValidationRule(BaseRule):
     def check(self, tree: ast.AST, file_path: str, source_code: str) -> List[LintIssue]:
         issues = []
 
-        for node in ast.walk(tree):
-            if isinstance(node, ast.Call) and self._is_dag_call(node):
-                doc_md = self._extract_doc_md(node)
-                if doc_md is None:
-                    issues.append(
-                        self.create_issue(
-                            "DAG is missing doc_md documentation",
-                            file_path,
-                            node.lineno,
-                            node.col_offset,
-                        )
+        for definition in self._find_dag_definitions(tree):
+            doc_md = self._extract_doc_md(definition.get_kwarg("doc_md"))
+            if doc_md is None:
+                issues.append(
+                    self.create_issue(
+                        "DAG is missing doc_md documentation",
+                        file_path,
+                        definition.lineno,
+                        definition.col_offset,
                     )
-                elif doc_md.strip() == "":
-                    issues.append(
-                        self.create_issue(
-                            "DAG doc_md must not be empty",
-                            file_path,
-                            node.lineno,
-                            node.col_offset,
-                        )
+                )
+            elif doc_md.strip() == "":
+                issues.append(
+                    self.create_issue(
+                        "DAG doc_md must not be empty",
+                        file_path,
+                        definition.lineno,
+                        definition.col_offset,
                     )
+                )
 
         return issues
 
-    def _extract_doc_md(self, node: ast.Call) -> Optional[str]:
-        """Extract doc_md value from a DAG() call.
+    def _extract_doc_md(self, value: Optional[ast.expr]) -> Optional[str]:
+        """Extract a doc_md string from its argument value node.
 
         Returns None if doc_md is absent, the string value if it's a string literal,
         or a non-empty sentinel if it's any other expression (variable, call, etc.).
         """
-        for keyword in node.keywords:
-            if keyword.arg == "doc_md":
-                if isinstance(keyword.value, ast.Constant) and isinstance(keyword.value.value, str):
-                    return keyword.value.value
-                # Variable or other expression — treat as non-empty
-                return "<expression>"
-        return None
+        if value is None:
+            return None
+        if isinstance(value, ast.Constant) and isinstance(value.value, str):
+            return value.value
+        # Variable or other expression — treat as non-empty
+        return "<expression>"

--- a/src/daglint/rules/metadata/max_active_runs_validation.py
+++ b/src/daglint/rules/metadata/max_active_runs_validation.py
@@ -22,36 +22,32 @@ class MaxActiveRunsValidationRule(BaseRule):
         issues = []
         expected_max_active_runs = self.config.get("max_active_runs", 1)
 
-        for node in ast.walk(tree):
-            if isinstance(node, ast.Call) and self._is_dag_call(node):
-                max_active_runs = self._extract_max_active_runs(node)
+        for definition in self._find_dag_definitions(tree):
+            max_active_runs = self._extract_max_active_runs(definition.get_kwarg("max_active_runs"))
 
-                if max_active_runs is None:
-                    issues.append(
-                        self.create_issue(
-                            f"max_active_runs must be explicitly set to {expected_max_active_runs}",
-                            file_path,
-                            node.lineno,
-                            node.col_offset,
-                        )
+            if max_active_runs is None:
+                issues.append(
+                    self.create_issue(
+                        f"max_active_runs must be explicitly set to {expected_max_active_runs}",
+                        file_path,
+                        definition.lineno,
+                        definition.col_offset,
                     )
-                elif max_active_runs != expected_max_active_runs:
-                    issues.append(
-                        self.create_issue(
-                            f"max_active_runs is set to {max_active_runs}. Expected {expected_max_active_runs}",
-                            file_path,
-                            node.lineno,
-                            node.col_offset,
-                        )
+                )
+            elif max_active_runs != expected_max_active_runs:
+                issues.append(
+                    self.create_issue(
+                        f"max_active_runs is set to {max_active_runs}. Expected {expected_max_active_runs}",
+                        file_path,
+                        definition.lineno,
+                        definition.col_offset,
                     )
+                )
 
         return issues
 
-    def _extract_max_active_runs(self, node: ast.Call) -> Optional[int]:
-        """Extract max_active_runs from a DAG() call."""
-        for keyword in node.keywords:
-            if keyword.arg == "max_active_runs":
-                if isinstance(keyword.value, ast.Constant) and isinstance(keyword.value.value, int):
-                    return keyword.value.value
-
+    def _extract_max_active_runs(self, value: Optional[ast.expr]) -> Optional[int]:
+        """Extract an integer from a max_active_runs argument value node."""
+        if isinstance(value, ast.Constant) and isinstance(value.value, int):
+            return value.value
         return None

--- a/src/daglint/rules/metadata/tag_requirements.py
+++ b/src/daglint/rules/metadata/tag_requirements.py
@@ -1,7 +1,7 @@
 """Rule for validating required DAG tags."""
 
 import ast
-from typing import List
+from typing import List, Optional
 
 from daglint.models import LintIssue
 from daglint.rules.base import BaseRule
@@ -25,30 +25,26 @@ class TagRequirementsRule(BaseRule):
         if not required_tags:
             return issues
 
-        for node in ast.walk(tree):
-            if isinstance(node, ast.Call) and self._is_dag_call(node):
-                tags = self._extract_tags(node)
-                missing_tags = set(required_tags) - set(tags)
-                if missing_tags:
-                    issues.append(
-                        self.create_issue(
-                            f"Missing required tags: {', '.join(sorted(missing_tags))}",
-                            file_path,
-                            node.lineno,
-                            node.col_offset,
-                        )
+        for definition in self._find_dag_definitions(tree):
+            tags = self._extract_tags(definition.get_kwarg("tags"))
+            missing_tags = set(required_tags) - set(tags)
+            if missing_tags:
+                issues.append(
+                    self.create_issue(
+                        f"Missing required tags: {', '.join(sorted(missing_tags))}",
+                        file_path,
+                        definition.lineno,
+                        definition.col_offset,
                     )
+                )
 
         return issues
 
-    def _extract_tags(self, node: ast.Call) -> List[str]:
-        """Extract tags from a DAG() call."""
-        for keyword in node.keywords:
-            if keyword.arg == "tags":
-                if isinstance(keyword.value, ast.List):
-                    tags = []
-                    for elt in keyword.value.elts:
-                        if isinstance(elt, ast.Constant) and isinstance(elt.value, str):
-                            tags.append(elt.value)
-                    return tags
-        return []
+    def _extract_tags(self, value: Optional[ast.expr]) -> List[str]:
+        """Extract string tags from a tags argument value node."""
+        tags = []
+        if isinstance(value, ast.List):
+            for elt in value.elts:
+                if isinstance(elt, ast.Constant) and isinstance(elt.value, str):
+                    tags.append(elt.value)
+        return tags

--- a/src/daglint/rules/naming.py
+++ b/src/daglint/rules/naming.py
@@ -23,19 +23,17 @@ class DAGIDConventionRule(BaseRule):
         issues = []
         pattern = self.config.get("pattern", r"^[a-z][a-z0-9_]*$")
 
-        for node in ast.walk(tree):
-            # Look for DAG instantiation
-            if isinstance(node, ast.Call) and self._is_dag_call(node):
-                dag_id = self._extract_dag_id(node)
-                if dag_id and not re.match(pattern, dag_id):
-                    issues.append(
-                        self.create_issue(
-                            f"DAG ID '{dag_id}' does not match pattern '{pattern}'",
-                            file_path,
-                            node.lineno,
-                            node.col_offset,
-                        )
+        for definition in self._find_dag_definitions(tree):
+            dag_id = definition.dag_id
+            if dag_id and not re.match(pattern, dag_id):
+                issues.append(
+                    self.create_issue(
+                        f"DAG ID '{dag_id}' does not match pattern '{pattern}'",
+                        file_path,
+                        definition.lineno,
+                        definition.col_offset,
                     )
+                )
 
         return issues
 

--- a/tests/rules/test_dag_call_detection.py
+++ b/tests/rules/test_dag_call_detection.py
@@ -16,11 +16,13 @@ DAG_SCOPED_RULES = [
     "max_active_runs_validation",
 ]
 
-# The same minimal DAG — violating every DAG-scoped rule — spelled three ways.
+# The same minimal DAG — violating every DAG-scoped rule — spelled five ways.
 SPELLINGS = {
     "bare_name": "dag = DAG('InvalidDAGID')\n",
     "attribute": "import airflow\ndag = airflow.DAG('InvalidDAGID')\n",
     "context_manager": "with DAG('InvalidDAGID') as dag:\n    pass\n",
+    "taskflow": "from airflow.decorators import dag\n\n@dag('InvalidDAGID')\ndef my_pipeline():\n    pass\n",
+    "taskflow_bare": "from airflow.decorators import dag\n\n@dag\ndef InvalidDAGID():\n    pass\n",
 }
 
 
@@ -38,4 +40,6 @@ def test_rule_covers_all_dag_call_spellings(rule_id):
     for spelling, messages in results.items():
         assert messages, f"{rule_id} produced no issues for the {spelling} spelling"
 
-    assert results["bare_name"] == results["attribute"] == results["context_manager"]
+    reference = results["bare_name"]
+    for spelling, messages in results.items():
+        assert messages == reference, f"{rule_id}: {spelling} spelling diverges from bare_name"

--- a/tests/rules/test_dag_id_convention.py
+++ b/tests/rules/test_dag_id_convention.py
@@ -89,6 +89,33 @@ def my_pipeline():
         assert len(issues) == 1
         assert "BadDagId" in issues[0].message
 
+    def test_taskflow_dynamic_dag_id_skips_function_name(self):
+        """A dynamic dag_id= overrides the function name in Airflow, so
+        neither can be validated (#34 review)."""
+        code = """
+from airflow.decorators import dag
+
+@dag(dag_id=DYNAMIC_ID)
+def MyBadPipelineName():
+    pass
+"""
+        tree = ast.parse(code)
+        rule = DAGIDConventionRule()
+        issues = rule.check(tree, "test.py", code)
+        assert len(issues) == 0
+
+    def test_dynamic_positional_dag_id_skipped(self):
+        """A dynamic positional DAG ID cannot be validated."""
+        code = """
+from airflow import DAG
+
+dag = DAG(f"team_{suffix}")
+"""
+        tree = ast.parse(code)
+        rule = DAGIDConventionRule()
+        issues = rule.check(tree, "test.py", code)
+        assert len(issues) == 0
+
     def test_unrelated_decorator_not_matched(self):
         """Decorators that are not @dag do not create DAG definitions (#34)."""
         code = """

--- a/tests/rules/test_dag_id_convention.py
+++ b/tests/rules/test_dag_id_convention.py
@@ -45,6 +45,64 @@ dag = DAG(dag_id='valid_dag_id')
         issues = rule.check(tree, "test.py", code)
         assert len(issues) == 0
 
+    def test_taskflow_function_name_is_effective_dag_id(self):
+        """A bare @dag uses the function name as the DAG ID and validates it (#34)."""
+        code = """
+from airflow.decorators import dag
+
+@dag
+def MyBadPipelineName():
+    pass
+"""
+        tree = ast.parse(code)
+        rule = DAGIDConventionRule()
+        issues = rule.check(tree, "test.py", code)
+        assert len(issues) == 1
+        assert "MyBadPipelineName" in issues[0].message
+
+    def test_taskflow_explicit_dag_id_overrides_function_name(self):
+        """An explicit dag_id= on @dag(...) wins over the function name (#34)."""
+        code = """
+from airflow.decorators import dag
+
+@dag(dag_id='good_dag_id')
+def MyBadPipelineName():
+    pass
+"""
+        tree = ast.parse(code)
+        rule = DAGIDConventionRule()
+        issues = rule.check(tree, "test.py", code)
+        assert len(issues) == 0
+
+    def test_taskflow_attribute_decorator_form(self):
+        """@decorators.dag(...) attribute form is recognized (#34)."""
+        code = """
+from airflow import decorators
+
+@decorators.dag(dag_id='BadDagId')
+def my_pipeline():
+    pass
+"""
+        tree = ast.parse(code)
+        rule = DAGIDConventionRule()
+        issues = rule.check(tree, "test.py", code)
+        assert len(issues) == 1
+        assert "BadDagId" in issues[0].message
+
+    def test_unrelated_decorator_not_matched(self):
+        """Decorators that are not @dag do not create DAG definitions (#34)."""
+        code = """
+import functools
+
+@functools.cache
+def MyHelperFunction():
+    pass
+"""
+        tree = ast.parse(code)
+        rule = DAGIDConventionRule()
+        issues = rule.check(tree, "test.py", code)
+        assert len(issues) == 0
+
     def test_rule_has_metadata(self):
         """Test that rule has required metadata."""
         rule = DAGIDConventionRule()

--- a/tests/rules/test_owner_validation.py
+++ b/tests/rules/test_owner_validation.py
@@ -192,6 +192,21 @@ dag = models.DAG(
         assert len(issues) == 1
         assert "DAG owner must be specified" in issues[0].message
 
+    def test_taskflow_decorator_default_args_validated(self):
+        """default_args passed to @dag(...) is validated like DAG(...) (#34)."""
+        code = """
+from airflow.decorators import dag
+
+@dag(default_args={'retries': 2})
+def my_pipeline():
+    pass
+"""
+        tree = ast.parse(code)
+        rule = OwnerValidationRule({"valid_owners": ["data-team", "analytics-team"]})
+        issues = rule.check(tree, "test.py", code)
+        assert len(issues) == 1
+        assert "DAG owner must be specified" in issues[0].message
+
     def test_dynamic_owner_value_skipped(self):
         """Test that a non-literal owner value is skipped, not flagged."""
         code = """

--- a/tests/rules/test_required_dag_params.py
+++ b/tests/rules/test_required_dag_params.py
@@ -215,6 +215,21 @@ with TaskGroup('group', default_args={'retries': 1}):
         issues = rule.check(tree, "test.py", code)
         assert len(issues) == 0
 
+    def test_taskflow_decorator_default_args_checked(self):
+        """default_args passed to @dag(...) is checked for required params (#34)."""
+        code = """
+from airflow.decorators import dag
+
+@dag(default_args={'owner': 'airflow'})
+def my_pipeline():
+    pass
+"""
+        tree = ast.parse(code)
+        rule = RequiredDAGParamsRule({"required_params": ["owner", "start_date", "retries"]})
+        issues = rule.check(tree, "test.py", code)
+        assert len(issues) == 1
+        assert "Missing required parameters in default_args: retries, start_date" in issues[0].message
+
     def test_missing_params_listed_in_sorted_order(self):
         """Missing params are reported in deterministic (sorted) order."""
         code = """


### PR DESCRIPTION
## Summary

**PR 1 of 2 for #34** (do not auto-close — task-scoped rules follow in PR 2).

DAGs written with the TaskFlow API — the recommended style in modern Airflow — were completely invisible to the linter. Per the refined scope in #34 (definition-layer architecture, decided 2026-07-03):

### Definition layer

- **`DagDefinition`** (in `rules/base.py`) normalizes the two declaration styles — `DAG(...)` / `<module>.DAG(...)` calls and `@dag` / `@dag(...)` / `@<module>.dag(...)` decorated functions — behind `get_kwarg(name)` and an effective `dag_id` property (explicit positional/keyword argument, else the decorated function name — Airflow's own defaulting).
- **`BaseRule._find_dag_definitions(tree)`** walks a file once for both styles. Bare `@dag` (no parentheses) yields a definition with no kwargs, so absence rules fire exactly as they do for `DAG()`.
- **`_find_default_args_dicts` now feeds from the definition layer**, so `owner_validation` and `required_dag_params` cover `@dag(default_args={...})` with zero changes to those rules.

### Rules converted

All six DAG-scoped rules (`dag_id_convention`, `catchup_validation`, `schedule_validation`, `tag_requirements`, `doc_md_validation`, `max_active_runs_validation`) now iterate definitions instead of walking the AST themselves; their extractors operate on argument value nodes. `BaseRule._extract_dag_id` is superseded by `DagDefinition.dag_id` and removed.

### Guarding

The #33 spelling matrix grows `taskflow` and `taskflow_bare` spellings — every DAG-scoped rule must now produce identical issues across **five** spellings of the same violating DAG, permanently.

### Examples

- `examples/valid_taskflow_dag.py` — lints clean
- `examples/invalid_taskflow_dag.py` — 7 issues
- Drive-by: `examples/valid_dag.py` predated the doc_md rule and no longer lived up to its "passes all daglint checks" docstring (verified pre-existing on develop via `git stash`) — added the missing `doc_md`.

## Verification (end-to-end via CLI)

`examples/invalid_taskflow_dag.py` (previously: "All checks passed!", exit 0) now reports **7 issues from 7 rules**: dag_id_convention (PascalCase function name), doc_md, owner_validation (via decorator default_args), tags, required_dag_params, max_active_runs, catchup. Exit 1.

Regression: `examples/invalid_dag.py` still reports exactly 11 issues; `examples/valid_dag.py` and `examples/valid_taskflow_dag.py` are clean.

## Tests

- Matrix: 6 rules × 5 spellings, identical messages required
- dag_id semantics: bare `@dag` uses function name; explicit `dag_id=` overrides it; `@decorators.dag(...)` attribute form; unrelated decorators (`@functools.cache`) not matched
- `@dag(default_args={...})` validated by owner_validation and required_dag_params
- `make check` green (130 passed)

Part of #34 — behavior change (TaskFlow files gaining full DAG-scoped coverage) is release-notes worthy per the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
