### PR TITLE
fix: bump urllib3 from 2.6.3 to 2.7.0 (CVE-2026-44431/44432)

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -133,7 +133,7 @@ types-pyyaml==6.0.12.20250915
     # via daglint (pyproject.toml)
 typing-extensions==4.15.0
     # via mypy
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   requests
     #   twine


### PR DESCRIPTION
## What

Bumps `urllib3` from 2.6.3 to 2.7.0 in `requirements-dev.txt`.

## Why

Resolves two **high-severity** Dependabot alerts on `develop`. `urllib3` is a transitive dev dependency (via `requests` and `twine`):

- **CVE-2026-44431** — sensitive headers forwarded across origins in proxied low-level redirects
- **CVE-2026-44432** — decompression-bomb safeguards bypassed in parts of the streaming API

Dependabot PR #26 proposed this exact bump but was closed unmerged and its branch deleted; the bot declined to reopen on request, so the pin is re-applied here by hand.

## Verification

- `pip check` — no broken requirements
- `make check` — all checks pass, 132 tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)