### PR TITLE
fix: schedule_validation message references schedule_interval, removed in Airflow 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ $ daglint check examples/invalid_dag.py
   WARNING [tag_requirements]           Line 19: Missing required tags: team, environment
   WARNING [max_active_runs_validation] Line 19: max_active_runs must be explicitly set to 1
   WARNING [catchup_validation]         Line 19: Catchup parameter not set. Consider setting it explicitly to False
-  WARNING [schedule_validation]        Line 19: schedule_interval must be explicitly set
+  WARNING [schedule_validation]        Line 19: schedule must be explicitly set
   ERROR   [task_id_convention]         Line 30: Task ID 'InvalidTaskID' does not match pattern '^[a-z][a-z0-9_]*$'
   ERROR   [task_id_convention]         Line 36: Task ID 'InvalidTaskID' does not match pattern '^[a-z][a-z0-9_]*$'
   ERROR   [no_duplicate_task_ids]      Line 36: Duplicate task_id 'InvalidTaskID' (first seen at line 30)

--- a/src/daglint/rules/configuration.py
+++ b/src/daglint/rules/configuration.py
@@ -94,7 +94,7 @@ class CatchupValidationRule(BaseRule):
 
 
 class ScheduleValidationRule(BaseRule):
-    """Validates schedule_interval is properly set."""
+    """Validates schedule is properly set."""
 
     @property
     def rule_id(self) -> str:
@@ -102,7 +102,7 @@ class ScheduleValidationRule(BaseRule):
 
     @property
     def description(self) -> str:
-        return "Schedule interval must be properly configured"
+        return "Schedule must be properly configured"
 
     def check(self, tree: ast.AST, file_path: str, source_code: str) -> List[LintIssue]:
         issues = []
@@ -113,7 +113,7 @@ class ScheduleValidationRule(BaseRule):
             if schedule_value is None and not allow_none:
                 issues.append(
                     self.create_issue(
-                        "schedule_interval must be explicitly set",
+                        "schedule must be explicitly set",
                         file_path,
                         definition.lineno,
                         definition.col_offset,

--- a/tests/rules/test_schedule_validation.py
+++ b/tests/rules/test_schedule_validation.py
@@ -31,7 +31,7 @@ dag = DAG('my_dag')
         rule = ScheduleValidationRule({"allow_none": False})
         issues = rule.check(tree, "test.py", code)
         assert len(issues) == 1
-        assert "schedule_interval must be explicitly set" in issues[0].message
+        assert "schedule must be explicitly set" in issues[0].message
 
     def test_rule_has_metadata(self):
         """Test that rule has required metadata."""


### PR DESCRIPTION
## Summary

`schedule_validation` already detects both the `schedule` and `schedule_interval` kwargs, but when neither is set the message told users to set `schedule_interval` — a parameter deprecated in Airflow 2.4 and removed in Airflow 3.0. This rewords the message to lead with the current kwarg name, per the wording agreed in the issue.

## Changes

- Message now reads `schedule must be explicitly set` (`src/daglint/rules/configuration.py`)
- Rule `description` and class docstring updated to match
- Updated the test assertion in `tests/rules/test_schedule_validation.py`
- Updated the sample output line in `README.md`

No behavioral change — detection logic is untouched.

## Testing

`make check` passes: black, isort, flake8, mypy, and all 143 tests.

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)