### PR TITLE
fix: make default config the single source of truth for rule defaults

### DIFF
--- a/src/daglint/config.py
+++ b/src/daglint/config.py
@@ -79,6 +79,19 @@ class Config:
             }
         }
 
+    @staticmethod
+    def default_rule_config(rule_id: str) -> Dict[str, Any]:
+        """Get the default configuration for a single rule.
+
+        Args:
+            rule_id: Rule identifier
+
+        Returns:
+            The rule's default configuration, or an empty dict for
+            rules not in the default config
+        """
+        return dict(Config._default_config()["rules"].get(rule_id, {}))
+
     @classmethod
     def default(cls) -> "Config":
         """Create a default configuration."""

--- a/src/daglint/rules/base.py
+++ b/src/daglint/rules/base.py
@@ -4,6 +4,7 @@ import ast
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional
 
+from daglint.config import Config
 from daglint.models import LintIssue
 
 
@@ -107,9 +108,12 @@ class BaseRule(ABC):
         """Initialize the rule.
 
         Args:
-            config: Rule-specific configuration
+            config: Rule-specific configuration. Keys not provided fall
+                back to the rule's entry in the default config, so the
+                default config is the single source of truth for
+                default values (#50).
         """
-        self.config = config or {}
+        self.config = {**Config.default_rule_config(self.rule_id), **(config or {})}
         self.severity = self.config.get("severity", "error")
 
     @property

--- a/src/daglint/rules/configuration.py
+++ b/src/daglint/rules/configuration.py
@@ -20,8 +20,8 @@ class RetryConfigurationRule(BaseRule):
 
     def check(self, tree: ast.AST, file_path: str, source_code: str) -> List[LintIssue]:
         issues = []
-        min_retries = self.config.get("min_retries", 1)
-        max_retries = self.config.get("max_retries", 5)
+        min_retries = self.config["min_retries"]
+        max_retries = self.config["max_retries"]
 
         for node in ast.walk(tree):
             if isinstance(node, ast.Dict):
@@ -70,7 +70,7 @@ class CatchupValidationRule(BaseRule):
 
     def check(self, tree: ast.AST, file_path: str, source_code: str) -> List[LintIssue]:
         issues = []
-        default_catchup = self.config.get("default_catchup", False)
+        default_catchup = self.config["default_catchup"]
 
         for definition in self._find_dag_definitions(tree):
             catchup_value = self._extract_catchup(definition.get_kwarg("catchup"))
@@ -106,7 +106,7 @@ class ScheduleValidationRule(BaseRule):
 
     def check(self, tree: ast.AST, file_path: str, source_code: str) -> List[LintIssue]:
         issues = []
-        allow_none = self.config.get("allow_none", False)
+        allow_none = self.config["allow_none"]
 
         for definition in self._find_dag_definitions(tree):
             schedule_value = definition.get_kwarg("schedule_interval") or definition.get_kwarg("schedule")

--- a/src/daglint/rules/metadata/max_active_runs_validation.py
+++ b/src/daglint/rules/metadata/max_active_runs_validation.py
@@ -20,7 +20,7 @@ class MaxActiveRunsValidationRule(BaseRule):
 
     def check(self, tree: ast.AST, file_path: str, source_code: str) -> List[LintIssue]:
         issues = []
-        expected_max_active_runs = self.config.get("max_active_runs", 1)
+        expected_max_active_runs = self.config["max_active_runs"]
 
         for definition in self._find_dag_definitions(tree):
             max_active_runs = self._extract_max_active_runs(definition.get_kwarg("max_active_runs"))

--- a/src/daglint/rules/metadata/owner_validation.py
+++ b/src/daglint/rules/metadata/owner_validation.py
@@ -20,7 +20,7 @@ class OwnerValidationRule(BaseRule):
 
     def check(self, tree: ast.AST, file_path: str, source_code: str) -> List[LintIssue]:
         issues = []
-        valid_owners = self.config.get("valid_owners", [])
+        valid_owners = self.config["valid_owners"]
 
         for node in self._find_default_args_dicts(tree):
             has_owner_key, owner_value = self._extract_owner_from_dict(node)

--- a/src/daglint/rules/metadata/required_dag_params.py
+++ b/src/daglint/rules/metadata/required_dag_params.py
@@ -20,7 +20,7 @@ class RequiredDAGParamsRule(BaseRule):
 
     def check(self, tree: ast.AST, file_path: str, source_code: str) -> List[LintIssue]:
         issues = []
-        required_params = self.config.get("required_params", ["owner", "start_date", "description"])
+        required_params = self.config["required_params"]
 
         for node in self._find_default_args_dicts(tree):
             present_params = self._extract_dict_keys(node)

--- a/src/daglint/rules/metadata/tag_requirements.py
+++ b/src/daglint/rules/metadata/tag_requirements.py
@@ -20,7 +20,7 @@ class TagRequirementsRule(BaseRule):
 
     def check(self, tree: ast.AST, file_path: str, source_code: str) -> List[LintIssue]:
         issues: list[LintIssue] = []
-        required_tags = self.config.get("required_tags", [])
+        required_tags = self.config["required_tags"]
 
         if not required_tags:
             return issues

--- a/src/daglint/rules/naming.py
+++ b/src/daglint/rules/naming.py
@@ -21,7 +21,7 @@ class DAGIDConventionRule(BaseRule):
 
     def check(self, tree: ast.AST, file_path: str, source_code: str) -> List[LintIssue]:
         issues = []
-        pattern = self.config.get("pattern", r"^[a-z][a-z0-9_]*$")
+        pattern = self.config["pattern"]
 
         for definition in self._find_dag_definitions(tree):
             dag_id = definition.dag_id
@@ -51,7 +51,7 @@ class TaskIDConventionRule(BaseRule):
 
     def check(self, tree: ast.AST, file_path: str, source_code: str) -> List[LintIssue]:
         issues = []
-        pattern = self.config.get("pattern", r"^[a-z][a-z0-9_]*$")
+        pattern = self.config["pattern"]
 
         for definition in self._find_task_definitions(tree):
             task_id = definition.task_id

--- a/tests/rules/test_config_defaults.py
+++ b/tests/rules/test_config_defaults.py
@@ -1,0 +1,52 @@
+"""Tests that the default config is the single source of truth for rule defaults (#50)."""
+
+import ast
+from typing import List
+
+import pytest
+
+from daglint.config import Config
+from daglint.models import LintIssue
+from daglint.rules import AVAILABLE_RULES
+from daglint.rules.base import BaseRule
+
+
+@pytest.mark.parametrize("rule_id", sorted(AVAILABLE_RULES))
+def test_unconfigured_rule_inherits_default_config(rule_id):
+    """A rule instantiated without config carries its full default config entry."""
+    rule = AVAILABLE_RULES[rule_id]()
+    for key, value in Config.default_rule_config(rule_id).items():
+        assert rule.config[key] == value
+
+
+@pytest.mark.parametrize("rule_id", sorted(AVAILABLE_RULES))
+def test_partial_config_inherits_default_severity(rule_id):
+    """A config that omits severity gets the documented default, not a hardcoded one."""
+    rule = AVAILABLE_RULES[rule_id]({"enabled": True})
+    assert rule.severity == Config.default_rule_config(rule_id)["severity"]
+
+
+def test_explicit_config_overrides_defaults():
+    """Explicitly configured values win over the default config."""
+    rule = AVAILABLE_RULES["schedule_validation"]({"severity": "error", "allow_none": True})
+    assert rule.severity == "error"
+    assert rule.config["allow_none"] is True
+
+
+def test_rule_without_default_config_entry_falls_back_to_error_severity():
+    """Rules unknown to the default config (e.g. third-party) default to error severity."""
+
+    class CustomRule(BaseRule):
+        @property
+        def rule_id(self) -> str:
+            return "custom_rule_not_in_default_config"
+
+        @property
+        def description(self) -> str:
+            return "Custom rule"
+
+        def check(self, tree: ast.AST, file_path: str, source_code: str) -> List[LintIssue]:
+            return []
+
+    rule = CustomRule()
+    assert rule.severity == "error"

--- a/tests/rules/test_owner_validation.py
+++ b/tests/rules/test_owner_validation.py
@@ -58,8 +58,20 @@ default_args = {
         assert len(issues) == 1
         assert "DAG owner must be specified" in issues[0].message
 
-    def test_valid_owner_no_validation_list(self):
-        """Test that any owner passes when no valid_owners list is provided."""
+    def test_valid_owner_empty_validation_list(self):
+        """Test that any owner passes when valid_owners is explicitly empty."""
+        code = """
+default_args = {
+    'owner': 'any-team'
+}
+"""
+        tree = ast.parse(code)
+        rule = OwnerValidationRule({"valid_owners": []})
+        issues = rule.check(tree, "test.py", code)
+        assert len(issues) == 0
+
+    def test_default_valid_owners_enforced_without_config(self):
+        """Owners are checked against the default config list when unconfigured (#50)."""
         code = """
 default_args = {
     'owner': 'any-team'
@@ -68,7 +80,8 @@ default_args = {
         tree = ast.parse(code)
         rule = OwnerValidationRule({})
         issues = rule.check(tree, "test.py", code)
-        assert len(issues) == 0
+        assert len(issues) == 1
+        assert "Invalid owner 'any-team'" in issues[0].message
 
     def test_non_default_args_dicts_ignored(self):
         """Test that dicts other than default_args are not inspected at all."""

--- a/tests/rules/test_required_dag_params.py
+++ b/tests/rules/test_required_dag_params.py
@@ -108,7 +108,7 @@ default_args = {
         assert len(issues) == 0
 
     def test_default_required_params(self):
-        """Test that default required params are used when none configured."""
+        """Test that the default config's required params are used when none configured (#50)."""
         code = """
 default_args = {
     'retries': 3
@@ -118,9 +118,7 @@ default_args = {
         rule = RequiredDAGParamsRule({})
         issues = rule.check(tree, "test.py", code)
         assert len(issues) == 1
-        assert "Missing required parameters" in issues[0].message
-        # Default params include owner, start_date, description
-        assert any(param in issues[0].message for param in ["owner", "start_date", "description"])
+        assert "Missing required parameters in default_args: owner, start_date" in issues[0].message
 
     def test_multiple_default_args(self):
         """Test that only the variable named 'default_args' is validated."""

--- a/tests/rules/test_tag_requirements.py
+++ b/tests/rules/test_tag_requirements.py
@@ -73,15 +73,15 @@ dag = DAG('my_dag', tags=[])
         assert len(issues) == 1
         assert "Missing required tags" in issues[0].message
 
-    def test_no_required_tags_configured(self):
-        """Test that no issues are raised when no required tags are configured."""
+    def test_empty_required_tags_configured(self):
+        """Test that no issues are raised when required_tags is explicitly empty."""
         code = """
 from airflow import DAG
 
 dag = DAG('my_dag')
 """
         tree = ast.parse(code)
-        rule = TagRequirementsRule({})
+        rule = TagRequirementsRule({"required_tags": []})
         issues = rule.check(tree, "test.py", code)
         assert len(issues) == 0
 


### PR DESCRIPTION
## Summary

`required_dag_params` fell back to `["owner", "start_date", "description"]` in code while the default config declares `["owner", "start_date", "retries"]`. Per the refinement decision on the issue, this fixes the whole class rather than the instance: **in-code fallbacks are removed and `Config._default_config()` is the single source of truth.**

## Changes

- `BaseRule.__init__` merges the rule's default config entry under any provided config (`src/daglint/rules/base.py`); new public helper `Config.default_rule_config(rule_id)`.
- All inline fallback literals deleted across the rules (`naming`, `configuration`, `owner_validation`, `tag_requirements`, `required_dag_params`, `max_active_runs_validation`).
- Rules absent from the default config (third-party subclasses) still fall back to `error` severity.
- New guard suite `tests/rules/test_config_defaults.py`: every registered rule inherits its full default config entry; partial configs inherit default severity; explicit config wins.

## Behavior change (intended)

A config file that lists a rule but **omits a key** now inherits the documented default instead of a hidden inline fallback:

- Omitting `severity` no longer silently escalates warnings to errors (verified: `schedule_validation: {enabled: true}` reported ERROR before, WARNING now).
- Omitting `valid_owners` / `required_tags` no longer silently disables validation — the default lists apply. Opt out explicitly with `valid_owners: []` / `required_tags: []` (covered by tests).

Runs with **no config file are byte-identical** to before (verified against `examples/invalid_dag.py`, including a `daglint init` roundtrip).

## Testing

`make check` passes: black, isort, flake8, mypy, and 168 tests (25 new). Also verified end-to-end via the CLI with partial/override/opt-out config files, comparing against pre-change behavior via stash.

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)