### PR TITLE
feat: dynamic task mapping support (.expand / .partial)

### DIFF
--- a/src/daglint/rules/base.py
+++ b/src/daglint/rules/base.py
@@ -219,6 +219,30 @@ class BaseRule(ABC):
             return node.func.attr.endswith("Operator")
         return False
 
+    def _is_operator_partial_call(self, node: ast.Call) -> bool:
+        """Check if a call is a dynamic-mapping Operator.partial(...) definition.
+
+        In Airflow's dynamic task mapping, `<X>Operator.partial(task_id=...)`
+        is the task definition site — it carries the constructor kwargs —
+        while the chained `.expand(...)` only supplies mapped arguments (#52).
+        TaskFlow `.partial()` calls (on decorated functions, not Operator
+        classes) are call sites of an existing definition and do not match.
+
+        Args:
+            node: AST Call node to check
+
+        Returns:
+            True if the call is an Operator.partial(...) definition
+        """
+        if not (isinstance(node.func, ast.Attribute) and node.func.attr == "partial"):
+            return False
+        target = node.func.value
+        if isinstance(target, ast.Name):
+            return target.id.endswith("Operator")
+        elif isinstance(target, ast.Attribute):
+            return target.attr.endswith("Operator")
+        return False
+
     def _is_dag_call(self, node: ast.Call) -> bool:
         """Check if a call is a DAG instantiation.
 
@@ -354,9 +378,14 @@ class BaseRule(ABC):
     def _find_task_definitions(self, tree: ast.AST) -> List[TaskDefinition]:
         """Find every task definition in a file.
 
-        Matches both declaration styles:
+        Matches all declaration styles:
             *Operator(...) instantiation calls
+            *Operator.partial(task_id=...) dynamic-mapping definitions (#52)
             @task / @task(...) / @task.<flavor> decorated functions (TaskFlow API)
+
+        `.expand(...)` / `.expand_kwargs(...)` calls and TaskFlow
+        `.partial()` calls are call sites of an existing definition,
+        never a second definition.
 
         Tasks lexically nested in `with TaskGroup(...)` blocks or
         @task_group-decorated functions carry the enclosing group IDs
@@ -387,7 +416,7 @@ class BaseRule(ABC):
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
             self._collect_from_function(node, prefix, definitions)
             return
-        if isinstance(node, ast.Call) and self._is_operator_call(node):
+        if isinstance(node, ast.Call) and (self._is_operator_call(node) or self._is_operator_partial_call(node)):
             definitions.append(TaskDefinition(call=node, group_prefix=prefix))
         for child in ast.iter_child_nodes(node):
             self._collect_task_definitions(child, prefix, definitions)

--- a/tests/rules/test_dynamic_task_mapping.py
+++ b/tests/rules/test_dynamic_task_mapping.py
@@ -1,0 +1,151 @@
+"""Tests for dynamic task mapping support (#52).
+
+`<X>Operator.partial(task_id=...)` is the definition site of a mapped
+classic operator and is subject to task rules; `.expand(...)`,
+`.expand_kwargs(...)`, and TaskFlow `.partial()` calls are call sites
+of an existing definition and must never count as a second one.
+"""
+
+import ast
+
+from daglint.rules import NoDuplicateTaskIDsRule, TaskIDConventionRule
+
+
+def test_partial_task_id_is_validated():
+    """task_id passed to Operator.partial(...) gets naming validation."""
+    code = """
+t = PythonOperator.partial(task_id="BadMappedName", python_callable=f).expand(op_args=[[1]])
+"""
+    tree = ast.parse(code)
+    rule = TaskIDConventionRule()
+    issues = rule.check(tree, "test.py", code)
+    assert len(issues) == 1
+    assert "Task ID 'BadMappedName'" in issues[0].message
+
+
+def test_mapped_task_collides_with_regular_task():
+    """A mapped task and a regular task with the same id are duplicates."""
+    code = """
+t1 = PythonOperator.partial(task_id="copy_files", python_callable=f).expand(op_args=[[1]])
+t2 = PythonOperator(task_id="copy_files", python_callable=f)
+"""
+    tree = ast.parse(code)
+    rule = NoDuplicateTaskIDsRule()
+    issues = rule.check(tree, "test.py", code)
+    assert len(issues) == 1
+    assert "Duplicate task_id 'copy_files'" in issues[0].message
+
+
+def test_two_mapped_tasks_with_same_id_are_duplicates():
+    """Two .partial() definitions with the same task_id are duplicates."""
+    code = """
+t1 = PythonOperator.partial(task_id="copy_files", python_callable=f).expand(op_args=[[1]])
+t2 = PythonOperator.partial(task_id="copy_files", python_callable=g).expand(op_args=[[2]])
+"""
+    tree = ast.parse(code)
+    rule = NoDuplicateTaskIDsRule()
+    issues = rule.check(tree, "test.py", code)
+    assert len(issues) == 1
+
+
+def test_module_qualified_operator_partial_detected():
+    """<module>.<X>Operator.partial(...) is detected like a direct call."""
+    code = """
+t = operators.PythonOperator.partial(task_id="BadMappedName").expand(op_args=[[1]])
+"""
+    tree = ast.parse(code)
+    rule = TaskIDConventionRule()
+    issues = rule.check(tree, "test.py", code)
+    assert len(issues) == 1
+
+
+def test_partial_inside_task_group_gets_group_prefix():
+    """Mapped tasks inside a TaskGroup carry the group prefix (#51 semantics)."""
+    code = """
+with TaskGroup("extract") as tg:
+    t1 = PythonOperator.partial(task_id="fetch", python_callable=f).expand(op_args=[[1]])
+    t2 = PythonOperator(task_id="fetch", python_callable=f)
+
+t3 = PythonOperator(task_id="fetch", python_callable=f)
+"""
+    tree = ast.parse(code)
+    rule = NoDuplicateTaskIDsRule()
+    issues = rule.check(tree, "test.py", code)
+    assert len(issues) == 1
+    assert "Duplicate task_id 'extract.fetch'" in issues[0].message
+
+
+def test_partial_without_task_id_is_skipped():
+    """A .partial() without a static task_id cannot be validated."""
+    code = """
+t1 = PythonOperator.partial(task_id=TASK_NAME, python_callable=f).expand(op_args=[[1]])
+t2 = PythonOperator.partial(python_callable=f).expand(op_args=[[1]])
+"""
+    tree = ast.parse(code)
+    for rule in (TaskIDConventionRule(), NoDuplicateTaskIDsRule()):
+        assert rule.check(tree, "test.py", code) == []
+
+
+def test_taskflow_expand_is_not_a_second_definition():
+    """Calling .expand() on a @task function does not re-define the task."""
+    code = """
+from airflow.decorators import task
+
+@task
+def transform(x):
+    return x
+
+transform.expand(x=[1, 2, 3])
+transform.expand(x=[4, 5, 6])
+"""
+    tree = ast.parse(code)
+    rule = NoDuplicateTaskIDsRule()
+    assert rule.check(tree, "test.py", code) == []
+
+
+def test_taskflow_partial_expand_is_not_a_second_definition():
+    """TaskFlow .partial(...).expand(...) chains are call sites, not definitions."""
+    code = """
+from airflow.decorators import task
+
+@task
+def BadName(x, y):
+    return x
+
+BadName.partial(y=1).expand(x=[1, 2])
+BadName.partial(y=2).expand(x=[3, 4])
+"""
+    tree = ast.parse(code)
+    convention_issues = TaskIDConventionRule().check(tree, "test.py", code)
+    assert len(convention_issues) == 1
+    assert NoDuplicateTaskIDsRule().check(tree, "test.py", code) == []
+
+
+def test_taskflow_expand_kwargs_is_not_a_definition():
+    """.expand_kwargs() call sites are not task definitions."""
+    code = """
+from airflow.decorators import task
+
+@task
+def transform(x):
+    return x
+
+transform.expand_kwargs([{"x": 1}, {"x": 2}])
+"""
+    tree = ast.parse(code)
+    rule = NoDuplicateTaskIDsRule()
+    assert rule.check(tree, "test.py", code) == []
+
+
+def test_unrelated_partial_calls_not_matched():
+    """functools.partial and other .partial() calls are not task definitions."""
+    code = """
+import functools
+
+f = functools.partial(g, task_id="NotATask")
+h = helper.partial(task_id="AlsoNotATask")
+i = make_operator().partial(task_id="StillNotATask")
+"""
+    tree = ast.parse(code)
+    for rule in (TaskIDConventionRule(), NoDuplicateTaskIDsRule()):
+        assert rule.check(tree, "test.py", code) == []


### PR DESCRIPTION
## Summary

Implements #52 on the #34/#51 detection layer. Airflow's dynamic task mapping defines classic-operator tasks through `<X>Operator.partial(task_id=..., ...)` (the constructor-kwargs site) followed by `.expand(...)` — previously daglint didn't see these tasks at all.

## Refinement decision

Full scope (per issue discussion): `.partial()` chains on Operator classes **are task definitions**; `.expand()` / `.expand_kwargs()` / TaskFlow `.partial()` calls **are call sites** and never count as a second definition (the latter was already true — now pinned by tests).

## Changes

- New `BaseRule._is_operator_partial_call`: matches `<X>Operator.partial(...)` and `<module>.<X>Operator.partial(...)`; wired into the scope-aware collector so mapped tasks also carry #51 group prefixes.
- Fixes two real false negatives (both verified via CLI before/after):
  - `PythonOperator.partial(task_id="BadMappedName", ...)` now fails `task_id_convention`
  - a mapped task colliding with a regular task (`copy_files` twice — an Airflow parse-time error) is now caught by `no_duplicate_task_ids`
- Non-matches by design: `functools.partial`, `.partial()` on arbitrary names or call results, TaskFlow `.partial()` on decorated functions.

## Testing

`make check` green: 206 tests (10 new in `test_dynamic_task_mapping.py`). CLI-verified on a mapping fixture (both false negatives now flagged, TaskFlow expand call sites stay clean) and output on mapping-free files is byte-identical to `develop`.

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)