### PR TITLE
feat: recognize .override(task_id=...) re-identification

### DIFF
--- a/src/daglint/rules/base.py
+++ b/src/daglint/rules/base.py
@@ -243,6 +243,27 @@ class BaseRule(ABC):
             return target.attr.endswith("Operator")
         return False
 
+    def _is_task_override_call(self, node: ast.Call) -> bool:
+        """Check if a call re-identifies a TaskFlow task via .override(task_id=...).
+
+        `my_task.override(task_id="other_id")(...)` instantiates the task
+        under a new ID at the call site (#53). Only calls that pass a
+        task_id are re-identifications; .override(pool=...) and friends
+        do not change task identity and are ignored, as are chains on
+        call results (only Name/Attribute targets match).
+
+        Args:
+            node: AST Call node to check
+
+        Returns:
+            True if the call is a task_id-overriding .override(...) call
+        """
+        if not (isinstance(node.func, ast.Attribute) and node.func.attr == "override"):
+            return False
+        if not isinstance(node.func.value, (ast.Name, ast.Attribute)):
+            return False
+        return any(keyword.arg == "task_id" for keyword in node.keywords)
+
     def _is_dag_call(self, node: ast.Call) -> bool:
         """Check if a call is a DAG instantiation.
 
@@ -382,10 +403,12 @@ class BaseRule(ABC):
             *Operator(...) instantiation calls
             *Operator.partial(task_id=...) dynamic-mapping definitions (#52)
             @task / @task(...) / @task.<flavor> decorated functions (TaskFlow API)
+            <task>.override(task_id=...) re-identification call sites (#53)
 
         `.expand(...)` / `.expand_kwargs(...)` calls and TaskFlow
         `.partial()` calls are call sites of an existing definition,
-        never a second definition.
+        never a second definition. An .override(...) without task_id
+        does not change task identity and is likewise ignored.
 
         Tasks lexically nested in `with TaskGroup(...)` blocks or
         @task_group-decorated functions carry the enclosing group IDs
@@ -416,7 +439,9 @@ class BaseRule(ABC):
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
             self._collect_from_function(node, prefix, definitions)
             return
-        if isinstance(node, ast.Call) and (self._is_operator_call(node) or self._is_operator_partial_call(node)):
+        if isinstance(node, ast.Call) and (
+            self._is_operator_call(node) or self._is_operator_partial_call(node) or self._is_task_override_call(node)
+        ):
             definitions.append(TaskDefinition(call=node, group_prefix=prefix))
         for child in ast.iter_child_nodes(node):
             self._collect_task_definitions(child, prefix, definitions)

--- a/tests/rules/test_override_reidentification.py
+++ b/tests/rules/test_override_reidentification.py
@@ -1,0 +1,139 @@
+"""Tests for .override(task_id=...) re-identification (#53).
+
+`my_task.override(task_id="other_id")(...)` instantiates a TaskFlow
+task under a new ID at the call site, so task rules must treat the
+override as a task definition with that ID. Overrides that do not
+pass task_id keep the original identity and are ignored.
+"""
+
+import ast
+
+from daglint.rules import NoDuplicateTaskIDsRule, TaskIDConventionRule
+
+
+def test_override_task_id_is_validated():
+    """task_id passed to .override(...) gets naming validation."""
+    code = """
+from airflow.decorators import task
+
+@task
+def process(x):
+    return x
+
+process.override(task_id="BadOverrideName")(1)
+"""
+    tree = ast.parse(code)
+    rule = TaskIDConventionRule()
+    issues = rule.check(tree, "test.py", code)
+    assert len(issues) == 1
+    assert "Task ID 'BadOverrideName'" in issues[0].message
+
+
+def test_distinct_overrides_are_not_duplicates():
+    """Reusing one @task under distinct override ids is legal."""
+    code = """
+from airflow.decorators import task
+
+@task
+def process(x):
+    return x
+
+process.override(task_id="process_a")(1)
+process.override(task_id="process_b")(2)
+"""
+    tree = ast.parse(code)
+    rule = NoDuplicateTaskIDsRule()
+    assert rule.check(tree, "test.py", code) == []
+
+
+def test_override_colliding_with_operator_id_is_a_duplicate():
+    """An override id colliding with a classic operator's id is flagged."""
+    code = """
+process.override(task_id="fetch")(1)
+t = PythonOperator(task_id="fetch", python_callable=f)
+"""
+    tree = ast.parse(code)
+    rule = NoDuplicateTaskIDsRule()
+    issues = rule.check(tree, "test.py", code)
+    assert len(issues) == 1
+    assert "Duplicate task_id 'fetch'" in issues[0].message
+
+
+def test_same_override_id_twice_is_a_duplicate():
+    """Two override call sites with the same explicit id are flagged."""
+    code = """
+process.override(task_id="copy")(1)
+process.override(task_id="copy")(2)
+"""
+    tree = ast.parse(code)
+    rule = NoDuplicateTaskIDsRule()
+    issues = rule.check(tree, "test.py", code)
+    assert len(issues) == 1
+
+
+def test_override_inside_task_group_gets_group_prefix():
+    """Override call sites carry the prefix of the group they run in (#51)."""
+    code = """
+with TaskGroup("extract") as tg:
+    process.override(task_id="fetch")(1)
+
+t = PythonOperator(task_id="fetch", python_callable=f)
+"""
+    tree = ast.parse(code)
+    rule = NoDuplicateTaskIDsRule()
+    assert rule.check(tree, "test.py", code) == []
+
+
+def test_override_chained_with_expand_counts_once():
+    """.override(task_id=...).expand(...) is one definition, not two."""
+    code = """
+process.override(task_id="mapped_copy").expand(x=[1, 2])
+process.override(task_id="mapped_copy").expand(x=[3, 4])
+"""
+    tree = ast.parse(code)
+    rule = NoDuplicateTaskIDsRule()
+    issues = rule.check(tree, "test.py", code)
+    assert len(issues) == 1
+
+
+def test_dynamic_override_id_is_skipped():
+    """A non-literal override id cannot be validated and is skipped."""
+    code = """
+process.override(task_id=TASK_NAME)(1)
+process.override(task_id=f"copy_{env}")(2)
+"""
+    tree = ast.parse(code)
+    for rule in (TaskIDConventionRule(), NoDuplicateTaskIDsRule()):
+        assert rule.check(tree, "test.py", code) == []
+
+
+def test_override_without_task_id_is_ignored():
+    """.override(pool=...) does not change task identity."""
+    code = """
+process.override(pool="high_memory")(1)
+process.override(pool="high_memory")(2)
+"""
+    tree = ast.parse(code)
+    for rule in (TaskIDConventionRule(), NoDuplicateTaskIDsRule()):
+        assert rule.check(tree, "test.py", code) == []
+
+
+def test_override_on_call_result_is_ignored():
+    """Chains on call results are not matched (conservative target scoping)."""
+    code = """
+make_task().override(task_id="BadName")(1)
+"""
+    tree = ast.parse(code)
+    for rule in (TaskIDConventionRule(), NoDuplicateTaskIDsRule()):
+        assert rule.check(tree, "test.py", code) == []
+
+
+def test_module_qualified_target_is_matched():
+    """Overrides on attribute targets like tasks.process are recognized."""
+    code = """
+tasks.process.override(task_id="BadOverrideName")(1)
+"""
+    tree = ast.parse(code)
+    rule = TaskIDConventionRule()
+    issues = rule.check(tree, "test.py", code)
+    assert len(issues) == 1


### PR DESCRIPTION
## Summary

Implements #53 on the #34/#51/#52 detection layer. `my_task.override(task_id="other_id")(...)` re-identifies a TaskFlow task at its call site; daglint previously didn't see these at all.

## Refinement decision

Override ids participate in **full duplicate detection** (not just naming): consistent with the existing test-pinned handling of `@task(task_id="x")` collisions, and it catches the override-vs-classic-operator collision that can genuinely break DAG loading (classic operators don't get TaskFlow's `__N` auto-suffixing, so whether the DAG parses depends on registration order).

## Changes

- New `BaseRule._is_task_override_call`: matches `.override(...)` on Name/Attribute targets **only when a `task_id` kwarg is present** — `.override(pool=...)` doesn't change identity and stays invisible, as do chains on call results.
- Wired into the scope-aware collector: override sites carry #51 group prefixes (the task belongs to the group where the call runs) and compose with #52 (`.override(task_id=...).expand(...)` counts once).
- Fixes two verified false negatives: bad override ids passing `task_id_convention`, and override/operator id collisions passing `no_duplicate_task_ids`. Distinct overrides of one `@task` remain legal reuse (test-pinned).

## Testing

`make check` green: 216 tests (10 new in `test_override_reidentification.py`). CLI-verified before/after on an override fixture; output on override-free files byte-identical to `develop`.

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)