### PR TITLE
feat: @setup / @teardown decorator support

### DIFF
--- a/src/daglint/rules/base.py
+++ b/src/daglint/rules/base.py
@@ -340,10 +340,14 @@ class BaseRule(ABC):
         return isinstance(target, ast.Name) and target.id == "task"
 
     def _is_setup_teardown_decorator(self, node: ast.expr) -> bool:
-        """Check if a decorator node is @setup or @teardown (bare or called).
+        """Check if a decorator node is @setup or @teardown.
 
         Both decorators turn a plain function into a TaskFlow task whose
         task_id is the function name — neither accepts a task_id (#54).
+        In Airflow only @teardown has a called form
+        (@teardown(on_failure_fail_dagrun=...)); @setup is bare-only.
+        A called @setup(...) still matches here — that code fails at
+        DAG-parse time, but linting its task is the graceful response.
 
         Args:
             node: Entry from a FunctionDef's decorator_list

--- a/src/daglint/rules/base.py
+++ b/src/daglint/rules/base.py
@@ -339,6 +339,26 @@ class BaseRule(ABC):
             target = target.value
         return isinstance(target, ast.Name) and target.id == "task"
 
+    def _is_setup_teardown_decorator(self, node: ast.expr) -> bool:
+        """Check if a decorator node is @setup or @teardown (bare or called).
+
+        Both decorators turn a plain function into a TaskFlow task whose
+        task_id is the function name — neither accepts a task_id (#54).
+
+        Args:
+            node: Entry from a FunctionDef's decorator_list
+
+        Returns:
+            True if the decorator is @setup, @teardown, @teardown(...),
+            or a module-qualified form of either
+        """
+        target = node.func if isinstance(node, ast.Call) else node
+        if isinstance(target, ast.Name):
+            return target.id in ("setup", "teardown")
+        elif isinstance(target, ast.Attribute):
+            return target.attr in ("setup", "teardown")
+        return False
+
     def _is_task_group_call(self, node: ast.Call) -> bool:
         """Check if a call is a TaskGroup instantiation.
 
@@ -403,6 +423,7 @@ class BaseRule(ABC):
             *Operator(...) instantiation calls
             *Operator.partial(task_id=...) dynamic-mapping definitions (#52)
             @task / @task(...) / @task.<flavor> decorated functions (TaskFlow API)
+            @setup / @teardown decorated functions (#54)
             <task>.override(task_id=...) re-identification call sites (#53)
 
         `.expand(...)` / `.expand_kwargs(...)` calls and TaskFlow
@@ -482,18 +503,31 @@ class BaseRule(ABC):
             definitions: Accumulator for found task definitions
         """
         body_prefix = prefix
+        group_decorator = None
+        task_decorator = None
+        setup_teardown_decorator = None
         for decorator in node.decorator_list:
-            if self._is_task_group_decorator(decorator):
-                call = decorator if isinstance(decorator, ast.Call) else None
-                group = TaskGroupDefinition(call=call, function_name=node.name, position=decorator)
-                segment = self._group_segment(group)
-                if segment is not None:
-                    body_prefix = body_prefix + (segment,)
-                break
-            if self._is_task_decorator(decorator):
-                call = decorator if isinstance(decorator, ast.Call) else None
-                definitions.append(TaskDefinition(call=call, function_name=node.name, position=decorator, group_prefix=prefix))
-                break
+            if group_decorator is None and self._is_task_group_decorator(decorator):
+                group_decorator = decorator
+            elif task_decorator is None and self._is_task_decorator(decorator):
+                task_decorator = decorator
+            elif setup_teardown_decorator is None and self._is_setup_teardown_decorator(decorator):
+                setup_teardown_decorator = decorator
+
+        if group_decorator is not None:
+            call = group_decorator if isinstance(group_decorator, ast.Call) else None
+            group = TaskGroupDefinition(call=call, function_name=node.name, position=group_decorator)
+            segment = self._group_segment(group)
+            if segment is not None:
+                body_prefix = body_prefix + (segment,)
+        else:
+            # In stacked forms like @setup over @task(task_id=...), the
+            # @task decorator carries the kwargs, so it wins the record.
+            marker = task_decorator if task_decorator is not None else setup_teardown_decorator
+            if marker is not None:
+                call = marker if isinstance(marker, ast.Call) else None
+                definitions.append(TaskDefinition(call=call, function_name=node.name, position=marker, group_prefix=prefix))
+
         for child in ast.iter_child_nodes(node):
             child_prefix = body_prefix if child in node.body else prefix
             self._collect_task_definitions(child, child_prefix, definitions)

--- a/tests/rules/test_setup_teardown.py
+++ b/tests/rules/test_setup_teardown.py
@@ -1,0 +1,141 @@
+"""Tests for @setup / @teardown decorator support (#54).
+
+Both decorators turn a plain function into a TaskFlow task whose
+task_id is the function name; neither accepts a task_id. They get
+ordinary task treatment — naming validation, duplicate detection,
+group prefixes — with no special-case rules.
+"""
+
+import ast
+
+from daglint.rules import NoDuplicateTaskIDsRule, TaskIDConventionRule
+
+
+def test_setup_function_name_is_validated():
+    """@setup functions are tasks; their names get naming validation."""
+    code = """
+from airflow.decorators import setup
+
+@setup
+def CreateCluster():
+    pass
+"""
+    tree = ast.parse(code)
+    rule = TaskIDConventionRule()
+    issues = rule.check(tree, "test.py", code)
+    assert len(issues) == 1
+    assert "Task ID 'CreateCluster'" in issues[0].message
+
+
+def test_teardown_called_form_is_a_task():
+    """@teardown(...) with kwargs is detected like the bare form."""
+    code = """
+from airflow.decorators import teardown
+
+@teardown(on_failure_fail_dagrun=True)
+def delete_cluster():
+    pass
+
+t = EmptyOperator(task_id="delete_cluster")
+"""
+    tree = ast.parse(code)
+    rule = NoDuplicateTaskIDsRule()
+    issues = rule.check(tree, "test.py", code)
+    assert len(issues) == 1
+    assert "Duplicate task_id 'delete_cluster'" in issues[0].message
+
+
+def test_distinct_setup_and_teardown_tasks_are_clean():
+    """Well-named, distinct setup/teardown tasks raise nothing."""
+    code = """
+from airflow.decorators import setup, teardown
+
+@setup
+def create_cluster():
+    pass
+
+@teardown
+def delete_cluster():
+    pass
+"""
+    tree = ast.parse(code)
+    for rule in (TaskIDConventionRule(), NoDuplicateTaskIDsRule()):
+        assert rule.check(tree, "test.py", code) == []
+
+
+def test_stacked_task_decorator_provides_explicit_id():
+    """@setup stacked over @task(task_id=...) uses the explicit id, once."""
+    code = """
+from airflow.decorators import setup, task
+
+@setup
+@task(task_id="explicit_id")
+def create_cluster():
+    pass
+
+t = EmptyOperator(task_id="explicit_id")
+"""
+    tree = ast.parse(code)
+    rule = NoDuplicateTaskIDsRule()
+    issues = rule.check(tree, "test.py", code)
+    assert len(issues) == 1
+    assert "Duplicate task_id 'explicit_id'" in issues[0].message
+
+
+def test_setup_inside_task_group_gets_group_prefix():
+    """Setup/teardown tasks in a group carry the group prefix (#51)."""
+    code = """
+with TaskGroup("cluster") as tg:
+    @setup
+    def create():
+        pass
+
+t = EmptyOperator(task_id="create")
+"""
+    tree = ast.parse(code)
+    rule = NoDuplicateTaskIDsRule()
+    assert rule.check(tree, "test.py", code) == []
+
+
+def test_module_qualified_decorator_form():
+    """@decorators.setup is recognized like the bare form."""
+    code = """
+from airflow import decorators
+
+@decorators.teardown
+def BadTeardownName():
+    pass
+"""
+    tree = ast.parse(code)
+    rule = TaskIDConventionRule()
+    issues = rule.check(tree, "test.py", code)
+    assert len(issues) == 1
+
+
+def test_as_setup_and_as_teardown_are_call_sites():
+    """.as_setup()/.as_teardown() convert existing tasks; no new definition."""
+    code = """
+t1 = EmptyOperator(task_id="cleanup").as_teardown()
+t2 = create_cluster().as_setup()
+"""
+    tree = ast.parse(code)
+    convention_issues = TaskIDConventionRule().check(tree, "test.py", code)
+    duplicate_issues = NoDuplicateTaskIDsRule().check(tree, "test.py", code)
+    assert convention_issues == []
+    assert duplicate_issues == []
+
+
+def test_unrelated_decorators_not_matched():
+    """Decorators merely containing 'setup' in the name are not tasks."""
+    code = """
+@setup_hook
+def configure():
+    pass
+
+@pytest.fixture
+def setup_db():
+    pass
+"""
+    tree = ast.parse(code)
+    for rule in (TaskIDConventionRule(), NoDuplicateTaskIDsRule()):
+        assert rule.check(tree, "test.py", code) == []


### PR DESCRIPTION
## Summary

Implements #54. Bare `@setup` / `@teardown` functions are TaskFlow tasks (function name = task_id; neither decorator accepts a `task_id` kwarg) but were invisible to task rules.

## Refinement decision

**Ordinary task treatment, no special rules** — naming validation, duplicate detection, and #51 group prefixes apply as for any task. A setup/teardown-specific naming convention (e.g. `setup_*` prefixes) was considered and deferred as a possible future opt-in rule.

## Changes

- New `BaseRule._is_setup_teardown_decorator` (bare, called, and module-qualified forms).
- `_collect_from_function` scans decorators in one pass for group/task/setup-teardown markers; in stacked forms (`@setup` over `@task(task_id=...)`) the `@task` decorator wins the record since it carries kwargs (test-pinned).
- `.as_setup()` / `.as_teardown()` conversions stay call sites — never a second definition (test-pinned).
- Fixes two verified false negatives: badly named `@setup` functions passing `task_id_convention`, and `@teardown` ids colliding with operator ids passing `no_duplicate_task_ids`.
- Decorators merely containing the words (`@setup_hook`, `@pytest.fixture` on `setup_db`) are not matched.

## Testing

`make check` green: 224 tests (8 new in `test_setup_teardown.py`). CLI-verified before/after on a setup/teardown fixture; output on unaffected files byte-identical to `develop`.

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)