### PR TITLE
feat: --format json/github output and errors-only exit codes

### DIFF
--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: verify
+description: How to run and verify the daglint CLI end-to-end in this repo.
+---
+
+# Verifying daglint
+
+The surface is the `daglint` CLI, installed editable in the project venv:
+
+```bash
+.venv/bin/daglint check examples/invalid_dag.py    # errors + warnings, exit 1
+.venv/bin/daglint check examples/valid_dag.py      # clean, exit 0
+```
+
+- `examples/` has ready-made valid/invalid fixtures (classic and TaskFlow).
+- For a warnings-only fixture, copy `examples/valid_dag.py` and delete the
+  `doc_md=` line — only the warning-severity `doc_md_validation` rule fires.
+- Always check `echo "EXIT=$?"` — exit-code semantics are part of the contract:
+  0 = clean or warnings-only, 1 = errors (or any issue with `--strict`), 2 = usage error.
+- `--format json` output must stay parseable when piped (`| python -m json.tool`),
+  including with `--verbose`.
+- `make check` runs format-check + lint + tests; run it before committing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- `--format [text|json|github]` option on `daglint check`: `json` emits a machine-readable envelope (`issues` list plus a `summary` block), `github` emits GitHub Actions workflow commands so issues appear as inline PR annotations (#39).
+- `--strict` flag: exit non-zero on any issue, not just errors (#39).
+
+### Changed
+- **Breaking for CI gating on warnings:** `daglint check` now exits 1 only when error-severity issues are found. Warning/info issues alone exit 0 unless `--strict` is passed. Exit code 2 means a usage error (#39).
+
 ## [0.6.1] - 2025-12-05
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -40,6 +40,15 @@ daglint check dags/
 # Run specific rules only
 daglint check dags/ --rules dag_id_convention,owner_validation
 
+# Machine-readable output for CI and editors
+daglint check dags/ --format json
+
+# GitHub Actions annotations (issues appear inline on PRs)
+daglint check dags/ --format github
+
+# Fail on warnings too, not just errors
+daglint check dags/ --strict
+
 # List all available rules
 daglint rules
 
@@ -55,6 +64,7 @@ $ daglint check examples/invalid_dag.py
   ERROR   [owner_validation]           Line  8: Invalid owner 'invalid-team'. Must be one of: data-team, analytics-team, airflow
   ERROR   [required_dag_params]        Line  8: Missing required parameters in default_args: retries, start_date
   ERROR   [dag_id_convention]          Line 19: DAG ID 'InvalidDAGID' does not match pattern '^[a-z][a-z0-9_]*$'
+  WARNING [doc_md_validation]          Line 19: DAG is missing doc_md documentation
   WARNING [tag_requirements]           Line 19: Missing required tags: team, environment
   WARNING [max_active_runs_validation] Line 19: max_active_runs must be explicitly set to 1
   WARNING [catchup_validation]         Line 19: Catchup parameter not set. Consider setting it explicitly to False
@@ -64,7 +74,7 @@ $ daglint check examples/invalid_dag.py
   ERROR   [no_duplicate_task_ids]      Line 36: Duplicate task_id 'InvalidTaskID' (first seen at line 30)
 
 --------------------------------------------------
-Found 10 issue(s) in 1 file(s).
+Found 11 issue(s) (6 error(s), 5 warning(s)) in 1 file(s).
 
 $ daglint check examples/valid_dag.py
 ✓ examples/valid_dag.py
@@ -72,6 +82,41 @@ $ daglint check examples/valid_dag.py
 --------------------------------------------------
 All checks passed!
 ```
+
+### Output formats
+
+`--format` selects how issues are reported (default `text`):
+
+- `text` — colorized human-readable output, as above.
+- `json` — a machine-readable envelope for CI systems, editors, and wrappers:
+
+  ```json
+  {
+    "issues": [
+      {
+        "rule_id": "owner_validation",
+        "severity": "warning",
+        "file": "dags/etl.py",
+        "line": 12,
+        "column": 0,
+        "message": "DAG must have an owner"
+      }
+    ],
+    "summary": {"files_checked": 8, "errors": 0, "warnings": 1, "infos": 0}
+  }
+  ```
+
+- `github` — GitHub Actions [workflow commands](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions) (`::error file=...,line=...::message`), so issues show up as inline annotations on pull requests.
+
+### Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | No issues found, or only warning/info issues without `--strict` |
+| 1 | At least one error-severity issue (with `--strict`: any issue at all) |
+| 2 | Usage error (unknown rule, bad flag, missing path) |
+
+Warning-severity issues are advisory and do not fail the build by default; pass `--strict` to make them fail CI.
 
 ## Configuration
 

--- a/src/daglint/cli.py
+++ b/src/daglint/cli.py
@@ -100,7 +100,7 @@ def _render_text(results: FileResults, exit_code: int, verbose: bool):
     summary_color = Fore.RED if exit_code else Fore.YELLOW
     click.echo(f"{summary_color}Found {total_issues} issue(s) ({detail}) in {len(results)} file(s).{Style.RESET_ALL}")
     if exit_code == 0:
-        click.echo("Warnings do not fail the build; use --strict to change that.")
+        click.echo("Non-error issues do not fail the build; use --strict to change that.")
 
 
 def _render_json(results: FileResults):
@@ -123,15 +123,23 @@ def _render_json(results: FileResults):
     click.echo(json.dumps(payload, indent=2))
 
 
+def _escape_github(value: str, is_property: bool = False) -> str:
+    """Escape a value for use in a GitHub Actions workflow command."""
+    value = value.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+    if is_property:
+        value = value.replace(":", "%3A").replace(",", "%2C")
+    return value
+
+
 def _render_github(results: FileResults):
     """Render results as GitHub Actions workflow commands."""
     command_for_severity = {"error": "error", "warning": "warning", "info": "notice"}
     all_issues = [issue for _, issues in results for issue in issues]
     for issue in all_issues:
         command = command_for_severity[issue.severity]
-        click.echo(
-            f"::{command} file={issue.file_path},line={issue.line},col={issue.column}" f"::[{issue.rule_id}] {issue.message}"
-        )
+        file_property = _escape_github(issue.file_path, is_property=True)
+        message = _escape_github(f"[{issue.rule_id}] {issue.message}")
+        click.echo(f"::{command} file={file_property},line={issue.line},col={issue.column}::{message}")
 
     counts = _severity_counts(all_issues)
     click.echo(

--- a/src/daglint/cli.py
+++ b/src/daglint/cli.py
@@ -1,15 +1,19 @@
 """Command-line interface for daglint."""
 
+import json
 import sys
 from pathlib import Path
-from typing import Optional
+from typing import List, Optional, Tuple
 
 import click
 from colorama import Fore, Style, init
 
 from daglint.config import Config
 from daglint.linter import DAGLinter
+from daglint.models import LintIssue
 from daglint.rules import AVAILABLE_RULES
+
+FileResults = List[Tuple[Path, List[LintIssue]]]
 
 # Initialize colorama for cross-platform colored output
 init(autoreset=True)
@@ -42,7 +46,27 @@ def _collect_files(target_path: Path) -> list:
     return list(target_path.rglob("*.py"))
 
 
-def _print_issue(issue):
+def _severity_counts(issues: List[LintIssue]) -> dict:
+    """Count issues by severity."""
+    counts = {"errors": 0, "warnings": 0, "infos": 0}
+    for issue in issues:
+        if issue.severity == "error":
+            counts["errors"] += 1
+        elif issue.severity == "warning":
+            counts["warnings"] += 1
+        else:
+            counts["infos"] += 1
+    return counts
+
+
+def _exit_code(issues: List[LintIssue], strict: bool) -> int:
+    """Determine the exit code: 1 on errors (or any issue with --strict), else 0."""
+    if strict:
+        return 1 if issues else 0
+    return 1 if any(issue.severity == "error" for issue in issues) else 0
+
+
+def _print_issue(issue: LintIssue):
     """Print a single linting issue."""
     severity_color = Fore.RED if issue.severity == "error" else Fore.YELLOW
     click.echo(
@@ -50,15 +74,70 @@ def _print_issue(issue):
     )
 
 
-def _print_summary(total_issues: int, file_count: int):
-    """Print summary of linting results."""
+def _render_text(results: FileResults, exit_code: int, verbose: bool):
+    """Render results as colorized human-readable text."""
+    total_issues = 0
+    for file_path, issues in results:
+        if verbose:
+            click.echo(f"\n{Fore.CYAN}Checking: {file_path}{Style.RESET_ALL}")
+        if issues:
+            total_issues += len(issues)
+            click.echo(f"\n{Fore.RED}✗ {file_path}{Style.RESET_ALL}")
+            for issue in issues:
+                _print_issue(issue)
+        else:
+            click.echo(f"{Fore.GREEN}✓ {file_path}{Style.RESET_ALL}")
+
     click.echo(f"\n{'-' * 50}")
     if total_issues == 0:
         click.echo(f"{Fore.GREEN}All checks passed!{Style.RESET_ALL}")
-        sys.exit(0)
-    else:
-        click.echo(f"{Fore.RED}Found {total_issues} issue(s) in {file_count} file(s).{Style.RESET_ALL}")
-        sys.exit(1)
+        return
+
+    counts = _severity_counts([issue for _, issues in results for issue in issues])
+    detail = f"{counts['errors']} error(s), {counts['warnings']} warning(s)"
+    if counts["infos"]:
+        detail += f", {counts['infos']} info(s)"
+    summary_color = Fore.RED if exit_code else Fore.YELLOW
+    click.echo(f"{summary_color}Found {total_issues} issue(s) ({detail}) in {len(results)} file(s).{Style.RESET_ALL}")
+    if exit_code == 0:
+        click.echo("Warnings do not fail the build; use --strict to change that.")
+
+
+def _render_json(results: FileResults):
+    """Render results as a machine-readable JSON envelope."""
+    all_issues = [issue for _, issues in results for issue in issues]
+    payload = {
+        "issues": [
+            {
+                "rule_id": issue.rule_id,
+                "severity": issue.severity,
+                "file": issue.file_path,
+                "line": issue.line,
+                "column": issue.column,
+                "message": issue.message,
+            }
+            for issue in all_issues
+        ],
+        "summary": {"files_checked": len(results), **_severity_counts(all_issues)},
+    }
+    click.echo(json.dumps(payload, indent=2))
+
+
+def _render_github(results: FileResults):
+    """Render results as GitHub Actions workflow commands."""
+    command_for_severity = {"error": "error", "warning": "warning", "info": "notice"}
+    all_issues = [issue for _, issues in results for issue in issues]
+    for issue in all_issues:
+        command = command_for_severity[issue.severity]
+        click.echo(
+            f"::{command} file={issue.file_path},line={issue.line},col={issue.column}" f"::[{issue.rule_id}] {issue.message}"
+        )
+
+    counts = _severity_counts(all_issues)
+    click.echo(
+        f"daglint checked {len(results)} file(s): "
+        f"{counts['errors']} error(s), {counts['warnings']} warning(s), {counts['infos']} info(s)."
+    )
 
 
 @cli.command()
@@ -66,10 +145,32 @@ def _print_summary(total_issues: int, file_count: int):
 @click.option("--config", "-c", type=click.Path(exists=True), help="Path to configuration file")
 @click.option("--rules", "-r", help="Comma-separated list of rules to check")
 @click.option("--verbose", "-v", is_flag=True, help="Verbose output")
-def check(path: str, config: Optional[str], rules: Optional[str], verbose: bool):
+@click.option(
+    "--format",
+    "-f",
+    "output_format",
+    type=click.Choice(["text", "json", "github"]),
+    default="text",
+    help="Output format: colorized text, a JSON envelope, or GitHub Actions annotations",
+)
+@click.option("--strict", is_flag=True, help="Exit non-zero on any issue, not just errors")
+def check(
+    path: str,
+    config: Optional[str],
+    rules: Optional[str],
+    verbose: bool,
+    output_format: str,
+    strict: bool,
+):
     """Check DAG files for linting issues.
 
     PATH can be a single file or a directory containing DAG files.
+
+    \b
+    Exit codes:
+      0  no issues (or only warnings/info without --strict)
+      1  error-severity issues found (any issue with --strict)
+      2  usage error
     """
     target_path = Path(path)
 
@@ -91,30 +192,24 @@ def check(path: str, config: Optional[str], rules: Optional[str], verbose: bool)
     # Collect files to lint
     files_to_check = _collect_files(target_path)
 
-    if not files_to_check:
+    if not files_to_check and output_format == "text":
         click.echo(f"{Fore.YELLOW}No Python files found to check.{Style.RESET_ALL}")
         sys.exit(0)
 
-    # Run linter
+    # Run linter, collecting all results before presenting them
     linter = DAGLinter(cfg, verbose=verbose)
-    total_issues = 0
+    results: FileResults = [(file_path, linter.lint_file(str(file_path))) for file_path in files_to_check]
+    all_issues = [issue for _, issues in results for issue in issues]
+    exit_code = _exit_code(all_issues, strict)
 
-    for file_path in files_to_check:
-        if verbose:
-            click.echo(f"\n{Fore.CYAN}Checking: {file_path}{Style.RESET_ALL}")
+    if output_format == "json":
+        _render_json(results)
+    elif output_format == "github":
+        _render_github(results)
+    else:
+        _render_text(results, exit_code, verbose)
 
-        issues = linter.lint_file(str(file_path))
-
-        if issues:
-            total_issues += len(issues)
-            click.echo(f"\n{Fore.RED}✗ {file_path}{Style.RESET_ALL}")
-            for issue in issues:
-                _print_issue(issue)
-        else:
-            click.echo(f"{Fore.GREEN}✓ {file_path}{Style.RESET_ALL}")
-
-    # Print summary
-    _print_summary(total_issues, len(files_to_check))
+    sys.exit(exit_code)
 
 
 @cli.command()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -293,7 +293,7 @@ def test_check_warnings_only_passes_by_default():
     result = _run_check(WARNINGS_ONLY_DAG)
     assert result.exit_code == 0
     assert "warning(s)" in result.output
-    assert "use --strict" in result.output
+    assert "do not fail the build; use --strict" in result.output
 
 
 def test_check_warnings_only_fails_with_strict():
@@ -360,6 +360,26 @@ def test_check_format_github_warning_severity():
     assert result.exit_code == 0
     assert "::warning file=" in result.output
     assert "::error" not in result.output
+
+
+def test_render_github_escapes_special_characters(capsys):
+    """Workflow-command properties and messages escape %, newlines, commas, colons."""
+    from daglint.cli import _render_github
+    from daglint.models import LintIssue
+
+    issue = LintIssue(
+        rule_id="demo_rule",
+        message="50% of tasks fail\nsee: docs",
+        file_path="dags/a,b:c.py",
+        line=3,
+        severity="warning",
+        column=1,
+    )
+    _render_github([(Path("dags/a,b:c.py"), [issue])])
+    out = capsys.readouterr().out
+    assert "::warning file=dags/a%2Cb%3Ac.py,line=3,col=1::" in out
+    assert "[demo_rule] 50%25 of tasks fail%0Asee: docs" in out
+    assert "\nsee" not in out.split("daglint checked")[0]
 
 
 def test_check_format_rejects_unknown():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,11 +1,62 @@
 """Tests for CLI commands."""
 
+import json
 import tempfile
 from pathlib import Path
 
 from click.testing import CliRunner
 
 from daglint.cli import cli
+
+# Passes every rule.
+CLEAN_DAG = """
+from datetime import datetime
+from airflow import DAG
+from airflow.operators.python import PythonOperator
+
+default_args = {
+    'owner': 'data-team',
+    'start_date': datetime(2023, 1, 1),
+    'retries': 3,
+}
+
+with DAG(
+    dag_id='my_valid_dag',
+    default_args=default_args,
+    schedule_interval='@daily',
+    max_active_runs=1,
+    catchup=False,
+    tags=['environment', 'team'],
+    doc_md='A valid DAG for testing.',
+) as dag:
+
+    task1 = PythonOperator(
+        task_id='my_task',
+        python_callable=lambda: print('Hello')
+    )
+"""
+
+# Same as CLEAN_DAG but without doc_md: trips only the warning-severity
+# doc_md_validation rule, no error-severity issues.
+WARNINGS_ONLY_DAG = CLEAN_DAG.replace("    doc_md='A valid DAG for testing.',\n", "")
+
+# Bad dag_id: trips the error-severity dag_id_convention rule.
+ERROR_DAG = """
+from airflow import DAG
+
+dag = DAG('InvalidDAGID')
+"""
+
+
+def _run_check(code, *args):
+    """Lint a temp file containing `code` with the given extra CLI args."""
+    runner = CliRunner()
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
+        f.write(code)
+    try:
+        return runner.invoke(cli, ["check", f.name, *args])
+    finally:
+        Path(f.name).unlink()
 
 
 def test_cli_version():
@@ -235,6 +286,97 @@ dag = DAG('my_dag')
         Path(f.name).unlink()
 
         assert "Checking:" in result.output
+
+
+def test_check_warnings_only_passes_by_default():
+    """Warning-severity issues alone must not fail the build (#39)."""
+    result = _run_check(WARNINGS_ONLY_DAG)
+    assert result.exit_code == 0
+    assert "warning(s)" in result.output
+    assert "use --strict" in result.output
+
+
+def test_check_warnings_only_fails_with_strict():
+    """--strict promotes warnings to build failures (#39)."""
+    result = _run_check(WARNINGS_ONLY_DAG, "--strict")
+    assert result.exit_code == 1
+
+
+def test_check_clean_passes_with_strict():
+    """--strict on a clean file still exits 0."""
+    result = _run_check(CLEAN_DAG, "--strict")
+    assert result.exit_code == 0
+    assert "All checks passed" in result.output
+
+
+def test_check_errors_fail_without_strict():
+    """Error-severity issues exit 1 regardless of --strict (#39)."""
+    result = _run_check(ERROR_DAG)
+    assert result.exit_code == 1
+    assert "error(s)" in result.output
+
+
+def test_check_format_json_clean():
+    """JSON output for a clean file is a parseable envelope with empty issues."""
+    result = _run_check(CLEAN_DAG, "--format", "json")
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["issues"] == []
+    assert payload["summary"] == {"files_checked": 1, "errors": 0, "warnings": 0, "infos": 0}
+
+
+def test_check_format_json_with_issues():
+    """JSON output carries every issue field and drives the same exit codes."""
+    result = _run_check(ERROR_DAG, "--format", "json")
+    assert result.exit_code == 1
+    payload = json.loads(result.output)
+    assert payload["summary"]["errors"] >= 1
+    issue = next(i for i in payload["issues"] if i["rule_id"] == "dag_id_convention")
+    assert issue["severity"] == "error"
+    assert set(issue) == {"rule_id", "severity", "file", "line", "column", "message"}
+    assert issue["file"].endswith(".py")
+    assert issue["line"] > 0
+
+
+def test_check_format_json_warnings_only_exit_codes():
+    """JSON format follows the same errors-only/--strict exit semantics."""
+    assert _run_check(WARNINGS_ONLY_DAG, "--format", "json").exit_code == 0
+    assert _run_check(WARNINGS_ONLY_DAG, "--format", "json", "--strict").exit_code == 1
+
+
+def test_check_format_github():
+    """GitHub format emits one workflow command per issue plus a summary."""
+    result = _run_check(ERROR_DAG, "--format", "github")
+    assert result.exit_code == 1
+    assert "::error file=" in result.output
+    assert ",line=" in result.output
+    assert "[dag_id_convention]" in result.output
+    assert "daglint checked 1 file(s)" in result.output
+
+
+def test_check_format_github_warning_severity():
+    """Warning-severity issues map to ::warning commands."""
+    result = _run_check(WARNINGS_ONLY_DAG, "--format", "github")
+    assert result.exit_code == 0
+    assert "::warning file=" in result.output
+    assert "::error" not in result.output
+
+
+def test_check_format_rejects_unknown():
+    """An unknown --format value is a usage error."""
+    result = _run_check(CLEAN_DAG, "--format", "yaml")
+    assert result.exit_code == 2
+
+
+def test_check_format_json_empty_directory():
+    """JSON on a directory with no Python files still emits a valid envelope."""
+    runner = CliRunner()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        result = runner.invoke(cli, ["check", tmpdir, "--format", "json"])
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["issues"] == []
+    assert payload["summary"]["files_checked"] == 0
 
 
 def test_check_help_does_not_advertise_fix():


### PR DESCRIPTION
## Summary

Implements the refined spec from #39 (see the refinement comment on the issue for the decisions):

- **`--format [text|json|github]`** on `daglint check` (default `text`, unchanged output):
  - `json` — machine-readable envelope: `issues` list (`rule_id`, `severity`, `file`, `line`, `column`, `message`) plus a `summary` block (`files_checked`, `errors`, `warnings`, `infos`). Stays parseable when piped, including with `--verbose`.
  - `github` — GitHub Actions workflow commands (`::error file=...,line=...,col=...::message`; `info` maps to `::notice`), so issues appear as inline PR annotations.
- **Errors-only exit codes**: exit 1 only when error-severity issues exist; warnings/info alone exit 0. New `--strict` flag fails on any issue. Exit 2 remains usage errors. Semantics documented in `check --help` and the README.
- **Collection separated from presentation**: `check` now gathers all results, computes the exit code, then hands off to one of three renderers.
- Text summary now breaks down counts by severity and notes when warnings were found but don't fail the build.

## Behavior change

⚠️ Repos gating CI on warnings will now pass unless they add `--strict`. Flagged in the CHANGELOG under Unreleased; per the refinement this should ship as **1.1.0**.

## Testing

- 11 new CLI tests: exit-code matrix (clean / warnings-only / errors × ±`--strict`), all three formats, JSON envelope shape, empty-directory and unknown-format edges. Full suite: 235 passed.
- Verified end-to-end against the installed CLI: drove `examples/invalid_dag.py` and a warnings-only fixture through all three formats and confirmed exit codes, JSON parseability when piped, and annotation syntax.
- Also fixed the stale README example output (missing `doc_md_validation` line) and added a project verify skill (`.claude/skills/verify/SKILL.md`) capturing the e2e recipe.

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)
