### PR TITLE
ci: harden workflows — permissions, Dependabot, CodeQL, SECURITY.md

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "python"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main, develop ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test on Python ${{ matrix.python-version }}
@@ -29,10 +32,9 @@ jobs:
       uses: actions/cache@v4
       with:
         path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements*.txt') }}
+        key: ${{ runner.os }}-pip-${{ hashFiles('pyproject.toml', 'requirements-dev.txt') }}
         restore-keys: |
           ${{ runner.os }}-pip-
-        save-always: true
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,6 +14,9 @@ permissions:
 jobs:
   analyze:
     name: Analyze Python
+    # Fork PRs get a read-only token without security-events: write, so the
+    # results upload would fail; forks are still covered by push + cron runs.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,37 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [ main, develop ]
+  pull_request:
+    branches: [ main, develop ]
+  schedule:
+    - cron: '26 7 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze Python
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v3
+      with:
+        languages: python
+        build-mode: none
+
+    - name: Perform CodeQL analysis
+      uses: github/codeql-action/analyze@v3
+      with:
+        category: "/language:python"

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -10,7 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
 
     steps:
     - name: Checkout code
@@ -38,21 +37,3 @@ jobs:
         flake8 src/daglint --count --statistics
         black --check src/daglint tests
         isort --check-only src/daglint tests
-
-    - name: Comment PR with test results
-      if: always()
-      uses: actions/github-script@v7
-      with:
-        script: |
-          const status = '${{ job.status }}';
-          const message = status === 'success' 
-            ? '✅ All tests passed! This PR is ready for review.'
-            : '❌ Some checks failed. Please review the logs and fix the issues.';
-          
-          await github.rest.issues.createComment({
-            issue_number: context.issue.number,
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            body: message
-          });
-

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,8 @@ Only the latest release of daglint receives security fixes.
 
 | Version | Supported |
 | ------- | --------- |
-| Latest 1.x | ✅ |
-| < 1.0 | ❌ |
+| Latest release | ✅ |
+| All older versions | ❌ |
 
 ## Reporting a Vulnerability
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,26 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest release of daglint receives security fixes.
+
+| Version | Supported |
+| ------- | --------- |
+| Latest 1.x | ✅ |
+| < 1.0 | ❌ |
+
+## Reporting a Vulnerability
+
+Please do not report security vulnerabilities in public issues.
+
+Instead, use [GitHub private vulnerability reporting](https://github.com/why-pengo/daglint/security/advisories/new)
+(Security tab → *Report a vulnerability*). You should receive an initial
+response within a week.
+
+## Scope
+
+daglint statically analyzes Python source with `ast.parse` and never imports
+or executes the code it lints. Configuration files are loaded with
+`yaml.safe_load`. Reports about daglint executing untrusted DAG code are
+likely out of scope, but reports about crashes, path traversal, or unsafe
+configuration handling are welcome.


### PR DESCRIPTION
## Summary

Implements the refined spec from #37 (decisions in the refinement comment):

1. **`permissions: contents: read`** added top-level to `ci.yml` — the default token was unscoped.
2. **Dependabot** — weekly updates for `pip` and `github-actions` ecosystems, using the existing `dependencies`/`python` labels.
3. **CodeQL** — Python analysis on push/PR to `main`+`develop` plus a weekly cron, `build-mode: none`.
4. **SECURITY.md** — supported versions, private-vulnerability-reporting link, and a scope note (daglint never executes linted code; config is `yaml.safe_load`).
5. **Cache cleanup** — removed the deprecated `save-always: true`, and fixed the cache key left stale by #40's `requirements.txt` deletion: it now hashes `pyproject.toml` + `requirements-dev.txt`.
6. **PR comment step removed** from `pr-checks.yml` (duplicated the checks UI on every push, failed on fork PRs), and its `pull-requests: write` permission dropped to `contents: read`.

Per the refinement: no SHA pinning — staying on major version tags with Dependabot watching the actions ecosystem.

## Owner follow-ups after merge

- Enable **Private vulnerability reporting** (Settings → Security) so the SECURITY.md link works.
- Dependabot and the CodeQL default-branch run activate once this lands on `develop`.

## Verification

- All four YAML files parse cleanly; `make check` green (246 tests).
- The real proof is this PR's own checks: `ci.yml`, `pr-checks.yml`, and the new `codeql.yml` all run from this branch — green checks here mean the hardened workflows work, and no ✅/❌ bot comment should appear below.

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)
