### PR TITLE
feat: release workflow with PyPI Trusted Publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,64 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v7
+
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: '3.10'
+
+    - name: Install build dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build twine
+
+    - name: Build sdist and wheel
+      run: |
+        python -m build
+
+    - name: Check package metadata with twine
+      run: |
+        twine check dist/*
+
+    - name: Upload distribution artifacts
+      uses: actions/upload-artifact@v7
+      with:
+        name: dist-packages
+        path: dist/
+
+  publish:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    needs: build
+    timeout-minutes: 15
+    environment:
+      name: pypi
+      url: https://pypi.org/project/daglint/
+    permissions:
+      id-token: write
+
+    steps:
+    - name: Download distribution artifacts
+      uses: actions/download-artifact@v8
+      with:
+        name: dist-packages
+        path: dist/
+
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -121,10 +121,12 @@ Open a PR from `develop` to `main` and merge it once CI passes.
 
 ### 3. Push the Tag
 
-bumpver already created the tag locally (unprefixed, e.g. `1.1.0`):
+bumpver already created the tag locally (unprefixed, e.g. `1.1.0`). Push only that
+tag — avoid `git push --tags`, which pushes every local tag and could trigger
+unintended release runs:
 
 ```bash
-git push origin --tags
+git push origin 1.1.0
 ```
 
 ### 4. Approve the Publish

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -87,7 +87,14 @@ repos:
 
 ## Publishing to PyPI
 
-When ready to release, the workflow is: bump the version on `develop`, open a PR to `main`, merge, push the tag, then publish manually.
+Releases are published automatically by CI (`.github/workflows/release.yml`) using
+[PyPI Trusted Publishing](https://docs.pypi.org/trusted-publishers/) — no API tokens or
+stored secrets. Pushing a release tag (unprefixed, e.g. `1.1.0`) triggers the workflow,
+which builds the sdist and wheel, verifies them with `twine check`, and publishes to
+PyPI from the protected `pypi` environment.
+
+The release flow is: bump the version on `develop`, open a PR to `main`, merge, push
+the tag — CI does the rest.
 
 ### 1. Update Version with Bumpver
 
@@ -108,82 +115,33 @@ This automatically updates:
 - `src/daglint/__init__.py`
 - `DEPLOYMENT.md`
 
-### 2. Build Distribution Packages
+### 2. Open and Merge the Release PR
+
+Open a PR from `develop` to `main` and merge it once CI passes.
+
+### 3. Push the Tag
+
+bumpver already created the tag locally (unprefixed, e.g. `1.1.0`):
 
 ```bash
-# Clean old builds
-rm -rf dist/ build/ *.egg-info
-
-# Build source and wheel distributions
-python -m build
-```
-
-This creates:
-- `dist/daglint-X.Y.Z.tar.gz` (source distribution)
-- `dist/daglint-X.Y.Z-py3-none-any.whl` (wheel distribution)
-
-### 3. Check Package with Twine
-
-```bash
-# Verify the package metadata and files
-python -m twine check dist/*
-```
-
-### 4. Test Upload to TestPyPI (Recommended)
-
-```bash
-# Upload to TestPyPI first
-python -m twine upload --repository testpypi dist/*
-
-# Test installation from TestPyPI
-pip install --index-url https://test.pypi.org/simple/ --no-deps daglint
-```
-
-### 5. Upload to Production PyPI
-
-```bash
-# Upload to production PyPI
-python -m twine upload dist/*
-```
-
-You'll be prompted for your PyPI credentials or API token.
-
-### 6. Push Tag and Verify
-
-After the release PR (`develop` → `main`) has been merged:
-
-```bash
-# Push the version tag created by bumpver
 git push origin --tags
 ```
 
-### Authentication Options
+### 4. Approve the Publish
 
-**Option 1: API Token (Recommended)**
+The tag push starts the **Release** workflow. It builds the sdist and wheel, runs
+`twine check`, then pauses: the publish job waits for approval on the `pypi`
+environment. Approve it under Actions → the workflow run → **Review deployments**.
+Once approved, CI publishes via Trusted Publishing (OIDC) — no credentials involved.
 
-Create a PyPI API token at https://pypi.org/manage/account/token/
+### 5. Verify
 
 ```bash
-# Set environment variables
-export TWINE_USERNAME=__token__
-export TWINE_PASSWORD=pypi-AgEIcHlwaS5vcmc...
-
-# Or use .pypirc file
-cat > ~/.pypirc << EOF
-[pypi]
-username = __token__
-password = pypi-AgEIcHlwaS5vcmc...
-
-[testpypi]
-username = __token__
-password = pypi-AgEIcHlwaS5vcmc...
-EOF
-chmod 600 ~/.pypirc
+pip install --upgrade daglint
+daglint --version
 ```
 
-**Option 2: Username/Password**
-
-Enter credentials when prompted by twine.
+Or check https://pypi.org/project/daglint/ for the new version.
 
 ## Monitoring and Maintenance
 


### PR DESCRIPTION
## Summary

Adds `.github/workflows/release.yml`: pushing an unprefixed release tag (bumpver style, e.g. `1.1.0`) now builds and publishes the package to PyPI automatically — no stored API tokens.

Implements the decisions refined in #38:

- **Trigger**: tag pushes matching `[0-9]+.[0-9]+.[0-9]+` (unprefixed, matching bumpver's existing tags — no `v` prefix)
- **Build job**: checkout → Python 3.10 → `python -m build` (sdist + wheel) → `twine check` → upload artifact
- **Publish job**: downloads the artifact and publishes via `pypa/gh-action-pypi-publish` with Trusted Publishing (OIDC, `id-token: write` scoped to this job only)
- **Environment**: `pypi`, with required-reviewer protection configured in repo settings, so every publish needs manual approval
- **DEPLOYMENT.md** rewritten: release flow is now bumpver on `develop` → PR `develop`→`main` → merge → push tag → approve the deployment; twine/.pypirc token and TestPyPI upload instructions removed
- Action versions match the just-merged Dependabot bumps (checkout@v7, setup-python@v6, upload-artifact@v7, download-artifact@v8)

## Pre-flight already done (repo owner)

- Trusted publisher configured on pypi.org (workflow `release.yml`, environment `pypi`)
- `pypi` environment created with required reviewers

Remaining after first successful publish: revoke the old twine API tokens.

## Test plan

- [x] `make check` green locally (246 tests)
- [ ] CI green on this PR
- [ ] First real validation is the 1.1.0 release (proving run of the pipeline)

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)