### PR TITLE
docs: update PyPI Development Status classifier to Production/Stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- PyPI Development Status classifier updated from `3 - Alpha` to `5 - Production/Stable` (#81).
+
 ## [1.1.0] - 2026-07-08
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ license = "MIT"
 license-files = ["LICENSE"]
 requires-python = ">=3.10"
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "Topic :: Software Development :: Quality Assurance",
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
## Summary

Updates the PyPI `Development Status` classifier from `3 - Alpha` to `5 - Production/Stable` in `pyproject.toml`, and adds a CHANGELOG entry under Unreleased.

daglint has shipped 1.0.0 and 1.1.0 to PyPI via the automated Trusted Publishing pipeline, and 1.x on semver implies a stable public API — the Alpha classifier no longer reflects reality. Skipping `4 - Beta` deliberately (decision recorded on the issue).

The new classifier will appear on the PyPI page with the next release (1.2.0).

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)