### PR TITLE
feat: import-alias resolution for DAG/task detection

### DIFF
--- a/.daglint.example.yaml
+++ b/.daglint.example.yaml
@@ -65,3 +65,7 @@ rules:
   doc_md_validation:
     enabled: true
     severity: warning
+
+  unresolved_airflow_symbol:
+    enabled: true
+    severity: info

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Import-alias resolution for DAG/task detection: a per-file symbol table maps local names to their origins, so aliased imports (`from airflow import DAG as Dag`, `import airflow.decorators as ad` + `@ad.task.branch`) are detected, including Airflow 3's `airflow.sdk` origins. The `*Operator` suffix check now applies to the alias-resolved origin name, and locally defined operator classes are recognized (#55).
+- `unresolved_airflow_symbol` rule (info severity): flags names that match DAG/task/task-group detection heuristics but are not traceable to any import or local definition, so untraceable files surface instead of silently linting green (#55).
+
 ### Changed
+- **Detection is now strict (#55):** airflow-owned symbols (`DAG`, `@dag`, `@task`, `@task_group`, `TaskGroup`, `@setup`/`@teardown`) only match when traceable to an airflow origin. Same-named symbols imported from other libraries no longer false-positive, and names with no binding are reported by `unresolved_airflow_symbol` instead of being matched. Files relying on `from <non-airflow module> import *` re-exports will see their DAGs skipped (with the info-level warning) until imports are made explicit.
 - PyPI Development Status classifier updated from `3 - Alpha` to `5 - Production/Stable` (#81).
 
 ## [1.1.0] - 2026-07-08

--- a/README.md
+++ b/README.md
@@ -19,6 +19,15 @@ A linting tool for Apache Airflow DAG files. Uses Python's AST to enforce standa
 | `max_active_runs_validation` | Ensures `max_active_runs` is explicitly set |
 | `catchup_validation` | Checks `catchup` is explicitly set |
 | `schedule_validation` | Ensures `schedule_interval` / `schedule` is set |
+| `doc_md_validation` | Warns when a DAG has no `doc_md` documentation |
+| `unresolved_airflow_symbol` | Flags Airflow-looking names not traceable to any import |
+
+Detection is import-aware: a name only counts as a DAG, task, or task group when it
+is traceable to its Airflow origin, so aliased imports (`from airflow import DAG as Dag`)
+are detected and same-named symbols from other libraries are not. Names that look like
+Airflow constructs but have no binding at all (star imports from non-airflow modules,
+generated fragments) are reported by `unresolved_airflow_symbol` at `info` severity
+instead of being silently skipped.
 
 ## Installation
 
@@ -198,6 +207,8 @@ src/daglint/
     naming.py         # dag_id_convention, task_id_convention, group_id_convention
     configuration.py  # retry_configuration, schedule_validation, catchup_validation
     validation.py     # no_duplicate_task_ids
+    resolution.py     # unresolved_airflow_symbol
+    symbols.py        # SymbolTable: import-alias resolution for detection
     metadata/         # owner_validation, tag_requirements, required_dag_params,
                       # max_active_runs_validation, doc_md_validation
 tests/

--- a/src/daglint/config.py
+++ b/src/daglint/config.py
@@ -122,6 +122,10 @@ class Config:
                     "enabled": True,
                     "severity": "warning",
                 },
+                "unresolved_airflow_symbol": {
+                    "enabled": True,
+                    "severity": "info",
+                },
             }
         }
 

--- a/src/daglint/rules/__init__.py
+++ b/src/daglint/rules/__init__.py
@@ -16,6 +16,7 @@ from daglint.rules.metadata import (
     TagRequirementsRule,
 )
 from daglint.rules.naming import DAGIDConventionRule, GroupIDConventionRule, TaskIDConventionRule
+from daglint.rules.resolution import UnresolvedAirflowSymbolRule
 from daglint.rules.validation import NoDuplicateTaskIDsRule
 
 # Registry of all available rules
@@ -32,6 +33,7 @@ AVAILABLE_RULES: Dict[str, Type[BaseRule]] = {
     "max_active_runs_validation": MaxActiveRunsValidationRule,
     "catchup_validation": CatchupValidationRule,
     "schedule_validation": ScheduleValidationRule,
+    "unresolved_airflow_symbol": UnresolvedAirflowSymbolRule,
 }
 
 __all__ = [
@@ -47,5 +49,6 @@ __all__ = [
     "MaxActiveRunsValidationRule",
     "CatchupValidationRule",
     "ScheduleValidationRule",
+    "UnresolvedAirflowSymbolRule",
     "AVAILABLE_RULES",
 ]

--- a/src/daglint/rules/base.py
+++ b/src/daglint/rules/base.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 from daglint.config import Config
 from daglint.models import LintIssue
+from daglint.rules.symbols import MATCH, SymbolTable
 
 
 class _AirflowDefinition:
@@ -177,6 +178,8 @@ class BaseRule(ABC):
         """
         self.config = {**Config.default_rule_config(self.rule_id), **(config or {})}
         self.severity = self.config.get("severity", "error")
+        self._symbols_tree: Optional[ast.AST] = None
+        self._symbols: Optional[SymbolTable] = None
 
     @property
     @abstractmethod
@@ -204,22 +207,41 @@ class BaseRule(ABC):
         """
         pass
 
-    def _is_operator_call(self, node: ast.Call) -> bool:
+    def _symbol_table(self, tree: ast.AST) -> SymbolTable:
+        """Build (or reuse) the symbol table for a file's AST.
+
+        Rules lint files one at a time, so a single-entry cache keyed
+        on tree identity avoids rebuilding the table for every
+        _find_* call within one check (#55).
+
+        Args:
+            tree: Abstract syntax tree of the file
+
+        Returns:
+            The file's SymbolTable
+        """
+        if self._symbols_tree is not tree or self._symbols is None:
+            self._symbols_tree = tree
+            self._symbols = SymbolTable(tree)
+        return self._symbols
+
+    def _is_operator_call(self, node: ast.Call, table: SymbolTable) -> bool:
         """Check if a call is an operator instantiation.
+
+        The *Operator suffix check applies to the alias-resolved origin
+        name, so `from x import FooOperator as fo` is detected and
+        `from x import Foo as FooOperator` is not (#55).
 
         Args:
             node: AST Call node to check
+            table: Symbol table of the file
 
         Returns:
             True if the call is an Operator instantiation
         """
-        if isinstance(node.func, ast.Name):
-            return node.func.id.endswith("Operator")
-        elif isinstance(node.func, ast.Attribute):
-            return node.func.attr.endswith("Operator")
-        return False
+        return table.classify_operator(node.func) == MATCH
 
-    def _is_operator_partial_call(self, node: ast.Call) -> bool:
+    def _is_operator_partial_call(self, node: ast.Call, table: SymbolTable) -> bool:
         """Check if a call is a dynamic-mapping Operator.partial(...) definition.
 
         In Airflow's dynamic task mapping, `<X>Operator.partial(task_id=...)`
@@ -230,18 +252,14 @@ class BaseRule(ABC):
 
         Args:
             node: AST Call node to check
+            table: Symbol table of the file
 
         Returns:
             True if the call is an Operator.partial(...) definition
         """
         if not (isinstance(node.func, ast.Attribute) and node.func.attr == "partial"):
             return False
-        target = node.func.value
-        if isinstance(target, ast.Name):
-            return target.id.endswith("Operator")
-        elif isinstance(target, ast.Attribute):
-            return target.attr.endswith("Operator")
-        return False
+        return table.classify_operator(node.func.value) == MATCH
 
     def _is_task_override_call(self, node: ast.Call) -> bool:
         """Check if a call re-identifies a TaskFlow task via .override(task_id=...).
@@ -264,36 +282,31 @@ class BaseRule(ABC):
             return False
         return any(keyword.arg == "task_id" for keyword in node.keywords)
 
-    def _is_dag_call(self, node: ast.Call) -> bool:
+    def _is_dag_call(self, node: ast.Call, table: SymbolTable) -> bool:
         """Check if a call is a DAG instantiation.
 
         Args:
             node: AST Call node to check
+            table: Symbol table of the file
 
         Returns:
-            True if the call is a DAG instantiation
+            True if the call resolves to Airflow's DAG
         """
-        if isinstance(node.func, ast.Name):
-            return node.func.id == "DAG"
-        elif isinstance(node.func, ast.Attribute):
-            return node.func.attr == "DAG"
-        return False
+        return table.classify(node.func, "DAG") == MATCH
 
-    def _is_dag_decorator(self, node: ast.expr) -> bool:
+    def _is_dag_decorator(self, node: ast.expr, table: SymbolTable) -> bool:
         """Check if a decorator node is an @dag decorator (bare or called).
 
         Args:
             node: Entry from a FunctionDef's decorator_list
+            table: Symbol table of the file
 
         Returns:
-            True if the decorator is @dag, @dag(...), or @<module>.dag(...)
+            True if the decorator resolves to Airflow's dag decorator
+            (bare, called, aliased, or module-qualified)
         """
         target = node.func if isinstance(node, ast.Call) else node
-        if isinstance(target, ast.Name):
-            return target.id == "dag"
-        elif isinstance(target, ast.Attribute):
-            return target.attr == "dag"
-        return False
+        return table.classify(target, "dag") == MATCH
 
     def _find_dag_definitions(self, tree: ast.AST) -> List[DagDefinition]:
         """Find every DAG definition in a file.
@@ -308,38 +321,37 @@ class BaseRule(ABC):
         Returns:
             List of normalized DAG definitions
         """
+        table = self._symbol_table(tree)
         definitions = []
         for node in ast.walk(tree):
-            if isinstance(node, ast.Call) and self._is_dag_call(node):
+            if isinstance(node, ast.Call) and self._is_dag_call(node, table):
                 definitions.append(DagDefinition(call=node))
             elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
                 for decorator in node.decorator_list:
-                    if self._is_dag_decorator(decorator):
+                    if self._is_dag_decorator(decorator, table):
                         call = decorator if isinstance(decorator, ast.Call) else None
                         definitions.append(DagDefinition(call=call, function_name=node.name, position=decorator))
                         break
         return definitions
 
-    def _is_task_decorator(self, node: ast.expr) -> bool:
+    def _is_task_decorator(self, node: ast.expr, table: SymbolTable) -> bool:
         """Check if a decorator node is an @task decorator (bare, called, or flavored).
 
         Matches @task, @task(...), flavors like @task.branch(...), and
-        module-qualified forms like @decorators.task(...).
+        module-qualified forms like @decorators.task(...), provided the
+        chain resolves to Airflow's task decorator.
 
         Args:
             node: Entry from a FunctionDef's decorator_list
+            table: Symbol table of the file
 
         Returns:
             True if the decorator declares a TaskFlow task
         """
         target = node.func if isinstance(node, ast.Call) else node
-        while isinstance(target, ast.Attribute):
-            if target.attr == "task":
-                return True
-            target = target.value
-        return isinstance(target, ast.Name) and target.id == "task"
+        return table.classify_chain(target, "task") == MATCH
 
-    def _is_setup_teardown_decorator(self, node: ast.expr) -> bool:
+    def _is_setup_teardown_decorator(self, node: ast.expr, table: SymbolTable) -> bool:
         """Check if a decorator node is @setup or @teardown.
 
         Both decorators turn a plain function into a TaskFlow task whose
@@ -351,49 +363,40 @@ class BaseRule(ABC):
 
         Args:
             node: Entry from a FunctionDef's decorator_list
+            table: Symbol table of the file
 
         Returns:
             True if the decorator is @setup, @teardown, @teardown(...),
             or a module-qualified form of either
         """
         target = node.func if isinstance(node, ast.Call) else node
-        if isinstance(target, ast.Name):
-            return target.id in ("setup", "teardown")
-        elif isinstance(target, ast.Attribute):
-            return target.attr in ("setup", "teardown")
-        return False
+        return MATCH in (table.classify(target, "setup"), table.classify(target, "teardown"))
 
-    def _is_task_group_call(self, node: ast.Call) -> bool:
+    def _is_task_group_call(self, node: ast.Call, table: SymbolTable) -> bool:
         """Check if a call is a TaskGroup instantiation.
 
         Args:
             node: AST Call node to check
+            table: Symbol table of the file
 
         Returns:
-            True if the call is a TaskGroup instantiation
+            True if the call resolves to Airflow's TaskGroup
         """
-        if isinstance(node.func, ast.Name):
-            return node.func.id == "TaskGroup"
-        elif isinstance(node.func, ast.Attribute):
-            return node.func.attr == "TaskGroup"
-        return False
+        return table.classify(node.func, "TaskGroup") == MATCH
 
-    def _is_task_group_decorator(self, node: ast.expr) -> bool:
+    def _is_task_group_decorator(self, node: ast.expr, table: SymbolTable) -> bool:
         """Check if a decorator node is an @task_group decorator (bare or called).
 
         Args:
             node: Entry from a FunctionDef's decorator_list
+            table: Symbol table of the file
 
         Returns:
-            True if the decorator is @task_group, @task_group(...), or
-            @<module>.task_group(...)
+            True if the decorator resolves to Airflow's task_group
+            decorator (bare, called, aliased, or module-qualified)
         """
         target = node.func if isinstance(node, ast.Call) else node
-        if isinstance(target, ast.Name):
-            return target.id == "task_group"
-        elif isinstance(target, ast.Attribute):
-            return target.attr == "task_group"
-        return False
+        return table.classify(target, "task_group") == MATCH
 
     def _group_segment(self, definition: TaskGroupDefinition) -> Optional[str]:
         """Segment a group contributes to the effective IDs of nested tasks.
@@ -445,34 +448,44 @@ class BaseRule(ABC):
         Returns:
             List of normalized task definitions
         """
+        table = self._symbol_table(tree)
         definitions: List[TaskDefinition] = []
         for node in ast.iter_child_nodes(tree):
-            self._collect_task_definitions(node, (), definitions)
+            self._collect_task_definitions(node, (), definitions, table)
         return definitions
 
-    def _collect_task_definitions(self, node: ast.AST, prefix: Tuple[str, ...], definitions: List[TaskDefinition]) -> None:
+    def _collect_task_definitions(
+        self, node: ast.AST, prefix: Tuple[str, ...], definitions: List[TaskDefinition], table: SymbolTable
+    ) -> None:
         """Recursively collect task definitions, tracking the group-prefix stack.
 
         Args:
             node: Node to visit
             prefix: Group ID segments of the enclosing task groups
             definitions: Accumulator for found task definitions
+            table: Symbol table of the file
         """
         if isinstance(node, (ast.With, ast.AsyncWith)):
-            self._collect_from_with(node, prefix, definitions)
+            self._collect_from_with(node, prefix, definitions, table)
             return
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-            self._collect_from_function(node, prefix, definitions)
+            self._collect_from_function(node, prefix, definitions, table)
             return
         if isinstance(node, ast.Call) and (
-            self._is_operator_call(node) or self._is_operator_partial_call(node) or self._is_task_override_call(node)
+            self._is_operator_call(node, table)
+            or self._is_operator_partial_call(node, table)
+            or self._is_task_override_call(node)
         ):
             definitions.append(TaskDefinition(call=node, group_prefix=prefix))
         for child in ast.iter_child_nodes(node):
-            self._collect_task_definitions(child, prefix, definitions)
+            self._collect_task_definitions(child, prefix, definitions, table)
 
     def _collect_from_with(
-        self, node: Union[ast.With, ast.AsyncWith], prefix: Tuple[str, ...], definitions: List[TaskDefinition]
+        self,
+        node: Union[ast.With, ast.AsyncWith],
+        prefix: Tuple[str, ...],
+        definitions: List[TaskDefinition],
+        table: SymbolTable,
     ) -> None:
         """Collect tasks from a with statement, entering TaskGroup scopes.
 
@@ -480,24 +493,26 @@ class BaseRule(ABC):
             node: The With/AsyncWith node
             prefix: Group ID segments of the enclosing task groups
             definitions: Accumulator for found task definitions
+            table: Symbol table of the file
         """
         body_prefix = prefix
         for item in node.items:
             context = item.context_expr
-            if isinstance(context, ast.Call) and self._is_task_group_call(context):
+            if isinstance(context, ast.Call) and self._is_task_group_call(context, table):
                 segment = self._group_segment(TaskGroupDefinition(call=context))
                 if segment is not None:
                     body_prefix = body_prefix + (segment,)
             else:
-                self._collect_task_definitions(context, prefix, definitions)
+                self._collect_task_definitions(context, prefix, definitions, table)
         for child in node.body:
-            self._collect_task_definitions(child, body_prefix, definitions)
+            self._collect_task_definitions(child, body_prefix, definitions, table)
 
     def _collect_from_function(
         self,
         node: Union[ast.FunctionDef, ast.AsyncFunctionDef],
         prefix: Tuple[str, ...],
         definitions: List[TaskDefinition],
+        table: SymbolTable,
     ) -> None:
         """Collect tasks from a function definition, entering @task_group scopes.
 
@@ -505,17 +520,18 @@ class BaseRule(ABC):
             node: The FunctionDef/AsyncFunctionDef node
             prefix: Group ID segments of the enclosing task groups
             definitions: Accumulator for found task definitions
+            table: Symbol table of the file
         """
         body_prefix = prefix
         group_decorator = None
         task_decorator = None
         setup_teardown_decorator = None
         for decorator in node.decorator_list:
-            if group_decorator is None and self._is_task_group_decorator(decorator):
+            if group_decorator is None and self._is_task_group_decorator(decorator, table):
                 group_decorator = decorator
-            elif task_decorator is None and self._is_task_decorator(decorator):
+            elif task_decorator is None and self._is_task_decorator(decorator, table):
                 task_decorator = decorator
-            elif setup_teardown_decorator is None and self._is_setup_teardown_decorator(decorator):
+            elif setup_teardown_decorator is None and self._is_setup_teardown_decorator(decorator, table):
                 setup_teardown_decorator = decorator
 
         if group_decorator is not None:
@@ -534,7 +550,7 @@ class BaseRule(ABC):
 
         for child in ast.iter_child_nodes(node):
             child_prefix = body_prefix if child in node.body else prefix
-            self._collect_task_definitions(child, child_prefix, definitions)
+            self._collect_task_definitions(child, child_prefix, definitions, table)
 
     def _find_task_group_definitions(self, tree: ast.AST) -> List[TaskGroupDefinition]:
         """Find every task group definition in a file.
@@ -549,13 +565,14 @@ class BaseRule(ABC):
         Returns:
             List of normalized task group definitions
         """
+        table = self._symbol_table(tree)
         definitions = []
         for node in ast.walk(tree):
-            if isinstance(node, ast.Call) and self._is_task_group_call(node):
+            if isinstance(node, ast.Call) and self._is_task_group_call(node, table):
                 definitions.append(TaskGroupDefinition(call=node))
             elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
                 for decorator in node.decorator_list:
-                    if self._is_task_group_decorator(decorator):
+                    if self._is_task_group_decorator(decorator, table):
                         call = decorator if isinstance(decorator, ast.Call) else None
                         definitions.append(TaskGroupDefinition(call=call, function_name=node.name, position=decorator))
                         break

--- a/src/daglint/rules/resolution.py
+++ b/src/daglint/rules/resolution.py
@@ -1,0 +1,86 @@
+"""Rules for import-resolution of Airflow symbols."""
+
+import ast
+from typing import List, Optional, Tuple
+
+from daglint.models import LintIssue
+from daglint.rules.base import BaseRule
+from daglint.rules.symbols import UNRESOLVED, SymbolTable, leaf_name
+
+
+class UnresolvedAirflowSymbolRule(BaseRule):
+    """Flags Airflow-looking symbols that no import or local definition binds.
+
+    Detection is strict (#55): a name only counts as a DAG, task, or
+    task group when it is traceable to its Airflow origin. Silently
+    skipping an untraceable name would make a file lint green without
+    ever being examined, so this rule surfaces the skip instead — a
+    star import, generated fragment, or dynamically bound name shows
+    up as an info issue rather than an invisible false negative.
+    """
+
+    @property
+    def rule_id(self) -> str:
+        return "unresolved_airflow_symbol"
+
+    @property
+    def description(self) -> str:
+        return "Airflow-looking symbols must be traceable to an import or local definition"
+
+    def check(self, tree: ast.AST, file_path: str, source_code: str) -> List[LintIssue]:
+        table = self._symbol_table(tree)
+        issues = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call):
+                finding = self._classify_call(node, table)
+            elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                for decorator in node.decorator_list:
+                    finding = self._classify_decorator(decorator, table)
+                    if finding is not None:
+                        name, kind = finding
+                        issues.append(self._unresolved_issue(name, kind, file_path, decorator))
+                continue
+            else:
+                continue
+            if finding is not None:
+                name, kind = finding
+                issues.append(self._unresolved_issue(name, kind, file_path, node))
+        return issues
+
+    def _classify_call(self, node: ast.Call, table: SymbolTable) -> Optional[Tuple[str, str]]:
+        """Return (name, kind) when a call matches detection by name but is unbound."""
+        func = node.func
+        if table.classify(func, "DAG") == UNRESOLVED:
+            return "DAG", "a DAG"
+        if table.classify(func, "TaskGroup") == UNRESOLVED:
+            return "TaskGroup", "a task group"
+        if table.classify_operator(func) == UNRESOLVED:
+            return leaf_name(func) or "", "an operator task"
+        if isinstance(func, ast.Attribute) and func.attr == "partial":
+            if table.classify_operator(func.value) == UNRESOLVED:
+                return leaf_name(func.value) or "", "an operator task"
+        return None
+
+    def _classify_decorator(self, node: ast.expr, table: SymbolTable) -> Optional[Tuple[str, str]]:
+        """Return (name, kind) when a decorator matches detection by name but is unbound."""
+        target = node.func if isinstance(node, ast.Call) else node
+        for expected, kind in (
+            ("dag", "the @dag decorator"),
+            ("task_group", "the @task_group decorator"),
+            ("setup", "the @setup decorator"),
+            ("teardown", "the @teardown decorator"),
+        ):
+            if table.classify(target, expected) == UNRESOLVED:
+                return expected, kind
+        if table.classify_chain(target, "task") == UNRESOLVED:
+            return "task", "the @task decorator"
+        return None
+
+    def _unresolved_issue(self, name: str, kind: str, file_path: str, node: ast.expr) -> LintIssue:
+        return self.create_issue(
+            f"'{name}' matches detection for {kind} by name but is not traceable to any "
+            f"import or local definition; rules will not lint it",
+            file_path,
+            node.lineno,
+            node.col_offset,
+        )

--- a/src/daglint/rules/symbols.py
+++ b/src/daglint/rules/symbols.py
@@ -54,24 +54,27 @@ class SymbolTable:
     """
 
     def __init__(self, tree: ast.AST):
-        """Build the table from a file's AST.
-
-        Args:
-            tree: Abstract syntax tree of the file
-        """
+        """Build the table from a file's AST."""
         self._bindings: Dict[str, str] = {}
         self._airflow_star = False
         local_names: List[str] = []
-        for node in ast.walk(tree):
-            if isinstance(node, ast.Import):
-                self._bind_import(node)
-            elif isinstance(node, ast.ImportFrom):
-                self._bind_import_from(node)
-            elif isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
-                local_names.append(node.name)
+
+        # Scope the collection to top-level nodes
+        nodes = getattr(tree, "body", ast.walk(tree))
+        for node in nodes:
+            self._process_node(node, local_names)
+
         # setdefault so imports win over local definitions of the same name
         for name in local_names:
             self._bindings.setdefault(name, f"{_LOCAL_ORIGIN}.{name}")
+
+    def _process_node(self, node: ast.AST, local_names: List[str]) -> None:
+        if isinstance(node, ast.Import):
+            self._bind_import(node)
+        elif isinstance(node, ast.ImportFrom):
+            self._bind_import_from(node)
+        elif isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+            local_names.append(node.name)
 
     def _bind_import(self, node: ast.Import) -> None:
         for alias in node.names:

--- a/src/daglint/rules/symbols.py
+++ b/src/daglint/rules/symbols.py
@@ -1,0 +1,186 @@
+"""Per-file symbol resolution for import-aware detection (#55).
+
+Detection used to be purely name-based, so aliased imports
+(`from airflow import DAG as Dag`) were invisible and unrelated
+same-named symbols (`from mylib import DAG`) false-positived. A
+SymbolTable maps each local name to its origin so detection can be
+strict: import-bound names are authoritative, and names with no
+binding at all are surfaced by the unresolved_airflow_symbol rule
+instead of being matched or silently skipped.
+"""
+
+import ast
+from typing import Dict, List, Optional
+
+# Classification of a call/decorator target against a detection pattern.
+MATCH = "match"
+NO_MATCH = "no_match"
+UNRESOLVED = "unresolved"
+
+_LOCAL_ORIGIN = "<local>"
+
+
+def _is_airflow_module(module: str) -> bool:
+    """Check whether a dotted module path belongs to Airflow.
+
+    Any `airflow.*` module counts — enumerating public paths would
+    break across Airflow versions (2.x `airflow.models.dag` vs 3.x
+    `airflow.sdk`), and a non-detection symbol imported from airflow
+    can never satisfy a leaf-name check anyway.
+    """
+    return module == "airflow" or module.startswith("airflow.")
+
+
+def leaf_name(node: ast.expr) -> Optional[str]:
+    """Rightmost name of a Name/Attribute target, as written in source."""
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    if isinstance(node, ast.Name):
+        return node.id
+    return None
+
+
+class SymbolTable:
+    """Maps a file's local names to their import origins.
+
+    Imports bind names to dotted origin paths (`from airflow import
+    DAG as Dag` binds `Dag` to `airflow.DAG`; `import airflow.decorators
+    as ad` binds `ad` to `airflow.decorators`). Class and function
+    definitions bind their name to a local origin, so in-file custom
+    operators are recognized and a local `def dag` shadows the airflow
+    decorator. Imports win over local definitions when both bind the
+    same name. A `from <airflow module> import *` makes name-matching
+    unbound symbols resolve to airflow instead of unresolved.
+    """
+
+    def __init__(self, tree: ast.AST):
+        """Build the table from a file's AST.
+
+        Args:
+            tree: Abstract syntax tree of the file
+        """
+        self._bindings: Dict[str, str] = {}
+        self._airflow_star = False
+        local_names: List[str] = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                self._bind_import(node)
+            elif isinstance(node, ast.ImportFrom):
+                self._bind_import_from(node)
+            elif isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+                local_names.append(node.name)
+        # setdefault so imports win over local definitions of the same name
+        for name in local_names:
+            self._bindings.setdefault(name, f"{_LOCAL_ORIGIN}.{name}")
+
+    def _bind_import(self, node: ast.Import) -> None:
+        for alias in node.names:
+            if alias.asname:
+                self._bindings[alias.asname] = alias.name
+            else:
+                # `import airflow.decorators` binds only `airflow`
+                top_level = alias.name.split(".", 1)[0]
+                self._bindings[top_level] = top_level
+
+    def _bind_import_from(self, node: ast.ImportFrom) -> None:
+        module = "." * node.level + (node.module or "")
+        for alias in node.names:
+            if alias.name == "*":
+                if _is_airflow_module(module):
+                    self._airflow_star = True
+                continue
+            local = alias.asname or alias.name
+            self._bindings[local] = f"{module}.{alias.name}"
+
+    def resolve_target(self, node: ast.expr) -> Optional[str]:
+        """Resolve a Name/Attribute chain to its full dotted origin path.
+
+        `ad.dag` resolves to `airflow.decorators.dag` when `ad` is bound
+        to `airflow.decorators`.
+
+        Args:
+            node: Call func or decorator target
+
+        Returns:
+            The dotted origin path, or None when the base of the chain
+            is not a bound name
+        """
+        attrs: List[str] = []
+        while isinstance(node, ast.Attribute):
+            attrs.append(node.attr)
+            node = node.value
+        if not isinstance(node, ast.Name):
+            return None
+        origin = self._bindings.get(node.id)
+        if origin is None:
+            return None
+        return ".".join([origin] + attrs[::-1])
+
+    def classify(self, node: ast.expr, expected: str) -> str:
+        """Classify a target against an airflow-owned symbol name.
+
+        Args:
+            node: Call func or decorator target
+            expected: The airflow symbol name (e.g. "DAG", "dag", "task")
+
+        Returns:
+            MATCH when the target resolves to the symbol in an airflow
+            module (or matches it by name under an airflow star import),
+            UNRESOLVED when it matches by name but nothing binds it,
+            NO_MATCH otherwise
+        """
+        origin = self.resolve_target(node)
+        if origin is not None:
+            module, _, leaf = origin.rpartition(".")
+            if leaf == expected and _is_airflow_module(module):
+                return MATCH
+            return NO_MATCH
+        if leaf_name(node) != expected:
+            return NO_MATCH
+        return MATCH if self._airflow_star else UNRESOLVED
+
+    def classify_chain(self, node: ast.expr, expected: str) -> str:
+        """Classify a dotted chain that may carry flavor attributes.
+
+        `@task.branch` and `@ad.task.branch` declare tasks even though
+        the chain does not end in `task`; each prefix of the chain is
+        tried against the expected symbol.
+
+        Args:
+            node: Decorator target (already unwrapped from a Call)
+            expected: The airflow symbol name (e.g. "task")
+
+        Returns:
+            The first non-NO_MATCH classification of any chain prefix,
+            or NO_MATCH
+        """
+        while True:
+            status = self.classify(node, expected)
+            if status != NO_MATCH:
+                return status
+            if not isinstance(node, ast.Attribute):
+                return NO_MATCH
+            node = node.value
+
+    def classify_operator(self, node: ast.expr) -> str:
+        """Classify a call target as an Operator by resolved-name suffix.
+
+        Custom operators live in user modules, so the origin is not
+        restricted to airflow — the *Operator suffix check applies to
+        the resolved origin name instead of the local alias. Locally
+        defined operator classes resolve to themselves and match.
+
+        Args:
+            node: Call func (or the target of a .partial(...) chain)
+
+        Returns:
+            MATCH, UNRESOLVED, or NO_MATCH
+        """
+        origin = self.resolve_target(node)
+        if origin is not None:
+            leaf = origin.rpartition(".")[2]
+            return MATCH if leaf.endswith("Operator") else NO_MATCH
+        written = leaf_name(node)
+        if written is None or not written.endswith("Operator"):
+            return NO_MATCH
+        return MATCH if self._airflow_star else UNRESOLVED

--- a/tests/rules/test_dag_call_detection.py
+++ b/tests/rules/test_dag_call_detection.py
@@ -16,11 +16,12 @@ DAG_SCOPED_RULES = [
     "max_active_runs_validation",
 ]
 
-# The same minimal DAG — violating every DAG-scoped rule — spelled five ways.
+# The same minimal DAG — violating every DAG-scoped rule — spelled six ways.
 SPELLINGS = {
-    "bare_name": "dag = DAG('InvalidDAGID')\n",
+    "bare_name": "from airflow import DAG\ndag = DAG('InvalidDAGID')\n",
+    "aliased": "from airflow import DAG as Dag\ndag = Dag('InvalidDAGID')\n",
     "attribute": "import airflow\ndag = airflow.DAG('InvalidDAGID')\n",
-    "context_manager": "with DAG('InvalidDAGID') as dag:\n    pass\n",
+    "context_manager": "from airflow import DAG\nwith DAG('InvalidDAGID') as dag:\n    pass\n",
     "taskflow": "from airflow.decorators import dag\n\n@dag('InvalidDAGID')\ndef my_pipeline():\n    pass\n",
     "taskflow_bare": "from airflow.decorators import dag\n\n@dag\ndef InvalidDAGID():\n    pass\n",
 }

--- a/tests/rules/test_dynamic_task_mapping.py
+++ b/tests/rules/test_dynamic_task_mapping.py
@@ -14,6 +14,7 @@ from daglint.rules import NoDuplicateTaskIDsRule, TaskIDConventionRule
 def test_partial_task_id_is_validated():
     """task_id passed to Operator.partial(...) gets naming validation."""
     code = """
+from airflow.operators.python import PythonOperator
 t = PythonOperator.partial(task_id="BadMappedName", python_callable=f).expand(op_args=[[1]])
 """
     tree = ast.parse(code)
@@ -26,6 +27,7 @@ t = PythonOperator.partial(task_id="BadMappedName", python_callable=f).expand(op
 def test_mapped_task_collides_with_regular_task():
     """A mapped task and a regular task with the same id are duplicates."""
     code = """
+from airflow.operators.python import PythonOperator
 t1 = PythonOperator.partial(task_id="copy_files", python_callable=f).expand(op_args=[[1]])
 t2 = PythonOperator(task_id="copy_files", python_callable=f)
 """
@@ -39,6 +41,7 @@ t2 = PythonOperator(task_id="copy_files", python_callable=f)
 def test_two_mapped_tasks_with_same_id_are_duplicates():
     """Two .partial() definitions with the same task_id are duplicates."""
     code = """
+from airflow.operators.python import PythonOperator
 t1 = PythonOperator.partial(task_id="copy_files", python_callable=f).expand(op_args=[[1]])
 t2 = PythonOperator.partial(task_id="copy_files", python_callable=g).expand(op_args=[[2]])
 """
@@ -51,6 +54,7 @@ t2 = PythonOperator.partial(task_id="copy_files", python_callable=g).expand(op_a
 def test_module_qualified_operator_partial_detected():
     """<module>.<X>Operator.partial(...) is detected like a direct call."""
     code = """
+import airflow.operators.python as operators
 t = operators.PythonOperator.partial(task_id="BadMappedName").expand(op_args=[[1]])
 """
     tree = ast.parse(code)
@@ -62,6 +66,8 @@ t = operators.PythonOperator.partial(task_id="BadMappedName").expand(op_args=[[1
 def test_partial_inside_task_group_gets_group_prefix():
     """Mapped tasks inside a TaskGroup carry the group prefix (#51 semantics)."""
     code = """
+from airflow.operators.python import PythonOperator
+from airflow.utils.task_group import TaskGroup
 with TaskGroup("extract") as tg:
     t1 = PythonOperator.partial(task_id="fetch", python_callable=f).expand(op_args=[[1]])
     t2 = PythonOperator(task_id="fetch", python_callable=f)
@@ -78,6 +84,7 @@ t3 = PythonOperator(task_id="fetch", python_callable=f)
 def test_partial_without_task_id_is_skipped():
     """A .partial() without a static task_id cannot be validated."""
     code = """
+from airflow.operators.python import PythonOperator
 t1 = PythonOperator.partial(task_id=TASK_NAME, python_callable=f).expand(op_args=[[1]])
 t2 = PythonOperator.partial(python_callable=f).expand(op_args=[[1]])
 """

--- a/tests/rules/test_group_id_convention.py
+++ b/tests/rules/test_group_id_convention.py
@@ -38,6 +38,7 @@ with TaskGroup("ExtractTasks") as tg:
     def test_group_id_keyword_arg(self):
         """Test that group_id passed as a keyword argument is validated."""
         code = """
+from airflow.utils.task_group import TaskGroup
 with TaskGroup(group_id="Extract-Tasks") as tg:
     pass
 """
@@ -50,6 +51,7 @@ with TaskGroup(group_id="Extract-Tasks") as tg:
     def test_assignment_form_validated(self):
         """Test that TaskGroup instantiations outside a with block are validated."""
         code = """
+from airflow.utils.task_group import TaskGroup
 tg = TaskGroup("BadName", dag=dag)
 """
         tree = ast.parse(code)
@@ -60,6 +62,7 @@ tg = TaskGroup("BadName", dag=dag)
     def test_attribute_call_form_validated(self):
         """Test that <module>.TaskGroup(...) is validated."""
         code = """
+from airflow.utils import task_group
 with task_group.TaskGroup("BadName") as tg:
     pass
 """
@@ -135,6 +138,7 @@ def my_group():
     def test_nested_groups_all_validated(self):
         """Every group in a nested structure is validated individually."""
         code = """
+from airflow.utils.task_group import TaskGroup
 with TaskGroup("outer_group") as outer:
     with TaskGroup("InnerGroup") as inner:
         pass

--- a/tests/rules/test_import_resolution.py
+++ b/tests/rules/test_import_resolution.py
@@ -1,0 +1,256 @@
+"""Tests for import-alias resolution in DAG/task detection (#55).
+
+Detection is strict: import-bound names are authoritative, airflow-owned
+symbols must trace to an airflow origin, and names that match detection
+by name but have no binding raise unresolved_airflow_symbol instead of
+matching or being silently skipped.
+"""
+
+import ast
+
+from daglint.rules import (
+    DAGIDConventionRule,
+    GroupIDConventionRule,
+    NoDuplicateTaskIDsRule,
+    TaskIDConventionRule,
+    UnresolvedAirflowSymbolRule,
+)
+
+
+def _issues(rule, code):
+    return rule.check(ast.parse(code), "test.py", code)
+
+
+class TestAliasedImportsAreDetected:
+    def test_aliased_dag_import(self):
+        """from airflow import DAG as Dag → Dag(...) is a DAG."""
+        code = """
+from airflow import DAG as Dag
+
+dag = Dag(dag_id="InvalidDAGID")
+"""
+        issues = _issues(DAGIDConventionRule(), code)
+        assert len(issues) == 1
+        assert "InvalidDAGID" in issues[0].message
+
+    def test_aliased_dag_decorator(self):
+        """from airflow.decorators import dag as d → @d declares a DAG."""
+        code = """
+from airflow.decorators import dag as d
+
+@d
+def InvalidDAGID():
+    pass
+"""
+        issues = _issues(DAGIDConventionRule(), code)
+        assert len(issues) == 1
+
+    def test_airflow_sdk_import(self):
+        """Airflow 3's airflow.sdk is an airflow origin."""
+        code = """
+from airflow.sdk import DAG
+
+dag = DAG(dag_id="InvalidDAGID")
+"""
+        assert len(_issues(DAGIDConventionRule(), code)) == 1
+
+    def test_module_alias_task_flavor_decorator(self):
+        """import airflow.decorators as ad → @ad.task.branch declares a task."""
+        code = """
+import airflow.decorators as ad
+
+@ad.task.branch
+def BadTaskName():
+    pass
+"""
+        issues = _issues(TaskIDConventionRule(), code)
+        assert len(issues) == 1
+        assert "BadTaskName" in issues[0].message
+
+    def test_aliased_operator_import(self):
+        """The *Operator suffix applies to the resolved origin name."""
+        code = """
+from my_company.operators import FooOperator as fo
+
+t = fo(task_id="BadTaskName")
+"""
+        assert len(_issues(TaskIDConventionRule(), code)) == 1
+
+    def test_aliased_task_group_import(self):
+        """from airflow.utils.task_group import TaskGroup as TG → TG(...) is a group."""
+        code = """
+from airflow.utils.task_group import TaskGroup as TG
+
+with TG("BadGroupName") as tg:
+    pass
+"""
+        assert len(_issues(GroupIDConventionRule(), code)) == 1
+
+
+class TestImpostorsAreExcluded:
+    def test_non_airflow_dag_import(self):
+        """from mylib import DAG → DAG(...) is not Airflow's DAG."""
+        code = """
+from mylib import DAG
+
+dag = DAG(dag_id="InvalidDAGID")
+"""
+        assert _issues(DAGIDConventionRule(), code) == []
+        assert _issues(UnresolvedAirflowSymbolRule(), code) == []
+
+    def test_alias_that_looks_like_an_operator(self):
+        """from x import Foo as FooOperator → origin name decides, no match."""
+        code = """
+from x import Foo as FooOperator
+
+t = FooOperator(task_id="BadTaskName")
+"""
+        assert _issues(TaskIDConventionRule(), code) == []
+        assert _issues(UnresolvedAirflowSymbolRule(), code) == []
+
+    def test_local_def_shadows_dag_decorator(self):
+        """A local def dag makes @dag a non-airflow decorator."""
+        code = """
+def dag(fn):
+    return fn
+
+@dag
+def InvalidDAGID():
+    pass
+"""
+        assert _issues(DAGIDConventionRule(), code) == []
+        assert _issues(UnresolvedAirflowSymbolRule(), code) == []
+
+    def test_non_airflow_task_decorator(self):
+        """@mylib.task is not a TaskFlow task."""
+        code = """
+import mylib
+
+@mylib.task
+def BadTaskName():
+    pass
+"""
+        assert _issues(TaskIDConventionRule(), code) == []
+        assert _issues(UnresolvedAirflowSymbolRule(), code) == []
+
+
+class TestLocalDefinitionsBind:
+    def test_local_operator_class_is_detected(self):
+        """An operator class defined in-file is a task definition site."""
+        code = """
+from airflow.models import BaseOperator
+
+class MyCustomOperator(BaseOperator):
+    pass
+
+t = MyCustomOperator(task_id="BadTaskName")
+"""
+        assert len(_issues(TaskIDConventionRule(), code)) == 1
+        assert _issues(UnresolvedAirflowSymbolRule(), code) == []
+
+
+class TestStarImports:
+    def test_airflow_star_import_binds_matching_names(self):
+        """from airflow.models import * → DAG(...) is detected, no warning."""
+        code = """
+from airflow.models import *
+
+dag = DAG(dag_id="InvalidDAGID")
+"""
+        assert len(_issues(DAGIDConventionRule(), code)) == 1
+        assert _issues(UnresolvedAirflowSymbolRule(), code) == []
+
+    def test_non_airflow_star_import_leaves_names_unresolved(self):
+        """from legacy_helpers import * → DAG(...) is unresolved and warned."""
+        code = """
+from legacy_helpers import *
+
+dag = DAG(dag_id="InvalidDAGID")
+"""
+        assert _issues(DAGIDConventionRule(), code) == []
+        assert len(_issues(UnresolvedAirflowSymbolRule(), code)) == 1
+
+
+class TestUnresolvedAirflowSymbolRule:
+    def test_unbound_dag_call_warns_once(self):
+        """A no-import DAG(...) yields exactly one info issue and no DAG issues."""
+        code = """
+dag = DAG(dag_id="InvalidDAGID")
+"""
+        assert _issues(DAGIDConventionRule(), code) == []
+        issues = _issues(UnresolvedAirflowSymbolRule(), code)
+        assert len(issues) == 1
+        assert issues[0].severity == "info"
+        assert "'DAG'" in issues[0].message
+
+    def test_unbound_operator_call_warns(self):
+        code = """
+t = PythonOperator(task_id="fetch")
+"""
+        assert _issues(TaskIDConventionRule(), code) == []
+        issues = _issues(UnresolvedAirflowSymbolRule(), code)
+        assert len(issues) == 1
+        assert "'PythonOperator'" in issues[0].message
+
+    def test_unbound_operator_partial_warns(self):
+        code = """
+t = PythonOperator.partial(task_id="fetch").expand(op_args=[[1]])
+"""
+        assert _issues(NoDuplicateTaskIDsRule(), code) == []
+        assert len(_issues(UnresolvedAirflowSymbolRule(), code)) == 1
+
+    def test_unbound_decorators_warn(self):
+        code = """
+@dag
+def my_pipeline():
+    @task
+    def extract():
+        pass
+
+    @task.branch
+    def fork():
+        pass
+"""
+        issues = _issues(UnresolvedAirflowSymbolRule(), code)
+        assert len(issues) == 3
+
+    def test_unbound_task_group_warns(self):
+        code = """
+with TaskGroup("extract") as tg:
+    pass
+"""
+        issues = _issues(UnresolvedAirflowSymbolRule(), code)
+        assert len(issues) == 1
+        assert "'TaskGroup'" in issues[0].message
+
+    def test_fully_imported_file_is_clean(self):
+        """A file with proper imports raises no unresolved issues."""
+        code = """
+from airflow import DAG
+from airflow.decorators import task
+from airflow.operators.python import PythonOperator
+from airflow.utils.task_group import TaskGroup
+
+with DAG(dag_id="my_dag") as dag:
+    with TaskGroup("extract") as tg:
+        t = PythonOperator(task_id="fetch")
+
+@task
+def transform():
+    pass
+"""
+        assert _issues(UnresolvedAirflowSymbolRule(), code) == []
+
+    def test_unrelated_calls_do_not_warn(self):
+        """Ordinary unbound calls are not airflow-looking and stay silent."""
+        code = """
+result = process(data)
+client = make_client(task_id="not_airflow")
+"""
+        assert _issues(UnresolvedAirflowSymbolRule(), code) == []
+
+    def test_rule_has_metadata(self):
+        rule = UnresolvedAirflowSymbolRule()
+        assert rule.rule_id == "unresolved_airflow_symbol"
+        assert rule.description
+        assert rule.severity == "info"

--- a/tests/rules/test_override_reidentification.py
+++ b/tests/rules/test_override_reidentification.py
@@ -49,6 +49,7 @@ process.override(task_id="process_b")(2)
 def test_override_colliding_with_operator_id_is_a_duplicate():
     """An override id colliding with a classic operator's id is flagged."""
     code = """
+from airflow.operators.python import PythonOperator
 process.override(task_id="fetch")(1)
 t = PythonOperator(task_id="fetch", python_callable=f)
 """

--- a/tests/rules/test_owner_validation.py
+++ b/tests/rules/test_owner_validation.py
@@ -138,6 +138,7 @@ dag = DAG(
     def test_inline_default_args_valid_owner(self):
         """Test that default_args passed inline to DAG() is validated."""
         code = """
+from airflow import DAG
 dag = DAG(
     dag_id="my_dag",
     default_args={'owner': 'data-team'},
@@ -151,6 +152,7 @@ dag = DAG(
     def test_inline_default_args_invalid_owner(self):
         """Test that invalid owners in inline default_args are caught."""
         code = """
+from airflow import DAG
 dag = DAG(
     dag_id="my_dag",
     default_args={'owner': 'invalid-team'},
@@ -165,6 +167,7 @@ dag = DAG(
     def test_inline_default_args_missing_owner(self):
         """Test that a missing owner key in inline default_args is caught."""
         code = """
+from airflow import DAG
 dag = DAG(
     dag_id="my_dag",
     default_args={'retries': 2},
@@ -194,6 +197,7 @@ with TaskGroup("group", default_args={'retries': 1}):
     def test_attribute_dag_call_inline_default_args_validated(self):
         """Test that models.DAG(default_args={...}) is still validated."""
         code = """
+from airflow import models
 dag = models.DAG(
     dag_id="my_dag",
     default_args={'retries': 2},
@@ -235,6 +239,7 @@ default_args = {
     def test_no_default_args_no_issues(self):
         """Test that a file without default_args produces no owner issues."""
         code = """
+from airflow import DAG
 dag = DAG(dag_id="my_dag")
 
 t1 = PythonOperator(

--- a/tests/rules/test_required_dag_params.py
+++ b/tests/rules/test_required_dag_params.py
@@ -123,6 +123,8 @@ default_args = {
     def test_multiple_default_args(self):
         """Test that only the variable named 'default_args' is validated."""
         code = """
+from airflow import DAG
+
 default_args = {
     'owner': 'airflow',
     'start_date': '2023-01-01'
@@ -154,6 +156,7 @@ default_args = {
     def test_inline_default_args_missing_params(self):
         """Test that inline DAG(default_args={...}) missing params is caught (#41)."""
         code = """
+from airflow import DAG
 dag = DAG(
     dag_id='my_dag',
     default_args={'owner': 'airflow'},
@@ -168,6 +171,7 @@ dag = DAG(
     def test_inline_default_args_all_params_present(self):
         """Test that inline default_args with all required params passes (#41)."""
         code = """
+from airflow import DAG
 dag = DAG(
     dag_id='my_dag',
     default_args={'owner': 'airflow', 'start_date': '2023-01-01', 'retries': 3},
@@ -181,6 +185,8 @@ dag = DAG(
     def test_assignment_and_inline_forms_both_checked(self):
         """Test that assignment and a separate inline default_args are each validated."""
         code = """
+from airflow import DAG
+
 default_args = {
     'owner': 'airflow',
     'start_date': '2023-01-01'

--- a/tests/rules/test_setup_teardown.py
+++ b/tests/rules/test_setup_teardown.py
@@ -10,12 +10,16 @@ import ast
 
 from daglint.rules import NoDuplicateTaskIDsRule, TaskIDConventionRule
 
+IMPORTS = """
+from airflow.decorators import setup, teardown, task
+from airflow.operators.empty import EmptyOperator
+from airflow.utils.task_group import TaskGroup
+"""
+
 
 def test_setup_function_name_is_validated():
     """@setup functions are tasks; their names get naming validation."""
-    code = """
-from airflow.decorators import setup
-
+    code = IMPORTS + """
 @setup
 def CreateCluster():
     pass
@@ -29,10 +33,7 @@ def CreateCluster():
 
 def test_teardown_called_form_is_a_task():
     """@teardown(...) with kwargs is detected like the bare form."""
-    code = """
-from airflow.decorators import teardown
-from airflow.operators.empty import EmptyOperator
-
+    code = IMPORTS + """
 @teardown(on_failure_fail_dagrun=True)
 def delete_cluster():
     pass
@@ -48,9 +49,7 @@ t = EmptyOperator(task_id="delete_cluster")
 
 def test_distinct_setup_and_teardown_tasks_are_clean():
     """Well-named, distinct setup/teardown tasks raise nothing."""
-    code = """
-from airflow.decorators import setup, teardown
-
+    code = IMPORTS + """
 @setup
 def create_cluster():
     pass
@@ -66,10 +65,7 @@ def delete_cluster():
 
 def test_stacked_task_decorator_provides_explicit_id():
     """@setup stacked over @task(task_id=...) uses the explicit id, once."""
-    code = """
-from airflow.decorators import setup, task
-from airflow.operators.empty import EmptyOperator
-
+    code = IMPORTS + """
 @setup
 @task(task_id="explicit_id")
 def create_cluster():
@@ -86,7 +82,7 @@ t = EmptyOperator(task_id="explicit_id")
 
 def test_setup_inside_task_group_gets_group_prefix():
     """Setup/teardown tasks in a group carry the group prefix (#51)."""
-    code = """
+    code = IMPORTS + """
 with TaskGroup("cluster") as tg:
     @setup
     def create():
@@ -116,9 +112,9 @@ def BadTeardownName():
 
 def test_as_setup_and_as_teardown_are_call_sites():
     """.as_setup()/.as_teardown() convert existing tasks; no new definition."""
-    code = """
+    code = IMPORTS + """
 t1 = EmptyOperator(task_id="cleanup").as_teardown()
-t2 = create_cluster().as_setup()
+t2 = EmptyOperator(task_id="create_cluster").as_setup()
 """
     tree = ast.parse(code)
     convention_issues = TaskIDConventionRule().check(tree, "test.py", code)

--- a/tests/rules/test_setup_teardown.py
+++ b/tests/rules/test_setup_teardown.py
@@ -31,6 +31,7 @@ def test_teardown_called_form_is_a_task():
     """@teardown(...) with kwargs is detected like the bare form."""
     code = """
 from airflow.decorators import teardown
+from airflow.operators.empty import EmptyOperator
 
 @teardown(on_failure_fail_dagrun=True)
 def delete_cluster():
@@ -67,6 +68,7 @@ def test_stacked_task_decorator_provides_explicit_id():
     """@setup stacked over @task(task_id=...) uses the explicit id, once."""
     code = """
 from airflow.decorators import setup, task
+from airflow.operators.empty import EmptyOperator
 
 @setup
 @task(task_id="explicit_id")

--- a/tests/rules/test_task_detection.py
+++ b/tests/rules/test_task_detection.py
@@ -8,8 +8,8 @@ from daglint.rules import NoDuplicateTaskIDsRule, TaskIDConventionRule
 
 # The same violating task — bad task ID — spelled six ways.
 SPELLINGS = {
-    "operator": "t = PythonOperator(task_id='BadTaskName')\n",
-    "operator_attribute": "t = operators.PythonOperator(task_id='BadTaskName')\n",
+    "operator": "from airflow.operators.python import PythonOperator\nt = PythonOperator(task_id='BadTaskName')\n",
+    "operator_attribute": "import airflow.operators.python as operators\nt = operators.PythonOperator(task_id='BadTaskName')\n",
     "taskflow_bare": "from airflow.decorators import task\n\n@task\ndef BadTaskName():\n    pass\n",
     "taskflow_call": "from airflow.decorators import task\n\n@task()\ndef BadTaskName():\n    pass\n",
     "taskflow_flavor": "from airflow.decorators import task\n\n@task.branch\ndef BadTaskName():\n    pass\n",

--- a/tests/rules/test_task_group_semantics.py
+++ b/tests/rules/test_task_group_semantics.py
@@ -9,10 +9,18 @@ import ast
 
 from daglint.rules import NoDuplicateTaskIDsRule, TaskIDConventionRule
 
+# Realistic import header for fixtures: strict detection (#55) only
+# recognizes names traceable to their airflow origins.
+IMPORTS = """\
+from airflow.decorators import task, task_group
+from airflow.operators.python import PythonOperator
+from airflow.utils.task_group import TaskGroup
+"""
+
 
 def test_same_leaf_id_in_different_groups_is_not_a_duplicate():
     """Same-named tasks in different groups have distinct effective IDs."""
-    code = """
+    code = IMPORTS + """
 with TaskGroup("extract_a") as g1:
     t1 = PythonOperator(task_id="fetch")
 
@@ -26,7 +34,7 @@ with TaskGroup("extract_b") as g2:
 
 def test_duplicate_within_a_group_reports_dotted_path():
     """Duplicates inside one group are caught, reported as group.task."""
-    code = """
+    code = IMPORTS + """
 with TaskGroup("extract") as tg:
     t1 = PythonOperator(task_id="fetch")
     t2 = PythonOperator(task_id="fetch")
@@ -40,7 +48,7 @@ with TaskGroup("extract") as tg:
 
 def test_grouped_task_does_not_collide_with_top_level_task():
     """group.task and a bare top-level task are distinct."""
-    code = """
+    code = IMPORTS + """
 t0 = PythonOperator(task_id="fetch")
 
 with TaskGroup("extract") as tg:
@@ -53,7 +61,7 @@ with TaskGroup("extract") as tg:
 
 def test_nested_groups_compose_dotted_path():
     """Nested groups prefix in order: outer.inner.task."""
-    code = """
+    code = IMPORTS + """
 with TaskGroup("outer") as o:
     with TaskGroup("inner") as i:
         t1 = PythonOperator(task_id="fetch")
@@ -68,7 +76,7 @@ with TaskGroup("outer") as o:
 
 def test_multiple_with_items_compose_in_order():
     """`with TaskGroup("a"), TaskGroup("b"):` prefixes as a.b."""
-    code = """
+    code = IMPORTS + """
 with TaskGroup("a"), TaskGroup("b"):
     t1 = PythonOperator(task_id="fetch")
     t2 = PythonOperator(task_id="fetch")
@@ -86,7 +94,7 @@ def test_prefix_group_id_false_adds_no_prefix():
     Same-named tasks in two unprefixed sibling groups collide at
     runtime, and the linter must catch that.
     """
-    code = """
+    code = IMPORTS + """
 with TaskGroup("extract_a", prefix_group_id=False) as g1:
     t1 = PythonOperator(task_id="fetch")
 
@@ -102,7 +110,7 @@ with TaskGroup("extract_b", prefix_group_id=False) as g2:
 
 def test_prefix_group_id_true_prefixes_normally():
     """An explicit prefix_group_id=True behaves like the default."""
-    code = """
+    code = IMPORTS + """
 with TaskGroup("extract_a", prefix_group_id=True) as g1:
     t1 = PythonOperator(task_id="fetch")
 
@@ -116,7 +124,7 @@ with TaskGroup("extract_b", prefix_group_id=True) as g2:
 
 def test_dynamic_group_id_still_catches_duplicates_within_the_group():
     """A group with a non-literal ID gets a unique placeholder prefix."""
-    code = """
+    code = IMPORTS + """
 with TaskGroup(GROUP_NAME) as tg:
     t1 = PythonOperator(task_id="fetch")
     t2 = PythonOperator(task_id="fetch")
@@ -129,7 +137,7 @@ with TaskGroup(GROUP_NAME) as tg:
 
 def test_dynamic_group_ids_never_collide_across_groups():
     """Two groups with unknown IDs cannot produce cross-group duplicates."""
-    code = """
+    code = IMPORTS + """
 with TaskGroup(NAME_A) as g1:
     t1 = PythonOperator(task_id="fetch")
 
@@ -143,7 +151,7 @@ with TaskGroup(NAME_B) as g2:
 
 def test_task_group_decorator_prefixes_body_tasks():
     """Tasks in an @task_group function are prefixed by the function name."""
-    code = """
+    code = IMPORTS + """
 from airflow.decorators import task, task_group
 
 @task_group
@@ -161,7 +169,7 @@ t0 = PythonOperator(task_id="fetch")
 
 def test_task_group_decorator_explicit_group_id_prefixes_body_tasks():
     """An explicit group_id on @task_group(...) is the prefix for body tasks."""
-    code = """
+    code = IMPORTS + """
 @task_group(group_id="extract")
 def some_group():
     @task
@@ -179,7 +187,7 @@ def some_group():
 
 def test_task_id_convention_validates_leaf_name_inside_groups():
     """The naming rule checks the leaf task_id, not the dotted path."""
-    code = """
+    code = IMPORTS + """
 with TaskGroup("extract") as tg:
     t1 = PythonOperator(task_id="good_name")
     t2 = PythonOperator(task_id="BadName")
@@ -193,7 +201,7 @@ with TaskGroup("extract") as tg:
 
 def test_task_id_convention_ignores_group_naming():
     """A badly named group does not make its well-named tasks fail."""
-    code = """
+    code = IMPORTS + """
 with TaskGroup("BadGroupName") as tg:
     t1 = PythonOperator(task_id="good_name")
 """


### PR DESCRIPTION
## Summary

Implements strict import-aware detection per the refinement decisions on #55.

### How it works
- **New `SymbolTable`** (`src/daglint/rules/symbols.py`): one lightweight pass per file maps local names to their origins — imports bind names to dotted origin paths, class/function definitions bind locally, imports win on conflicts. All `_is_*` detection helpers in `base.py` now consult it.
- **Strict for airflow-owned symbols:** `DAG`, `@dag`, `@task` (+ flavors), `@task_group`, `TaskGroup`, `@setup`/`@teardown` only match when traceable to an airflow origin — any `airflow.*` module counts, which covers 2.x paths and Airflow 3's `airflow.sdk` without enumerating.
- **Operators stay suffix-based, on the resolved origin name:** `from x import FooOperator as fo` → detected; `from x import Foo as FooOperator` → not. Locally defined `class MyOperator(BaseOperator)` counts as a binding.
- **New `unresolved_airflow_symbol` rule (info, disableable):** names matching detection heuristics with no binding at all raise a visible issue instead of matching (old behavior) or vanishing silently (strict without the net).
- **Star imports:** `from <airflow module> import *` binds matching names to airflow; star imports from elsewhere leave them unresolved → warned.

### Behavior changes
- Aliased airflow imports are now detected (new coverage).
- Same-named impostors (`from mylib import DAG`) no longer false-positive.
- Untraceable airflow-looking names (no imports at all) now produce one info issue and are otherwise skipped — exit code stays 0 unless `--strict`.

### Tests
- New `tests/rules/test_import_resolution.py` (21 tests) covering all acceptance criteria from #55.
- Existing fixtures updated to carry realistic airflow imports; detection-spelling matrices extended with an aliased spelling.
- Verified end-to-end via the CLI: aliased/impostor/unbound files, `--strict` exit codes, and `--format json` parseability.

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)